### PR TITLE
Fix check-in page bugs and add metadata to all pages

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -15,6 +15,7 @@ import LoginModal from '@/components/ui/LoginModal'
 import { useRouter } from "next/navigation";
 import * as CookieConsent from "vanilla-cookieconsent";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { updatePageMeta } from "@/utils/seo";
 
 export default function AccountPage() {
   const { notify } = useNotify();
@@ -28,6 +29,10 @@ export default function AccountPage() {
   const [confirmRegId, setConfirmRegId] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
+
+  useEffect(() => {
+    updatePageMeta('My Account', 'Manage your UU AI Society account and event registrations');
+  }, []);
 
   useEffect(() => {
     const unsub = auth.onAuthStateChanged(async (u) => {

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -12,6 +12,7 @@ import { format } from 'date-fns';
 import { incrementBlogRead } from '@/lib/firestore/analytics';
 import Tag from '@/components/ui/Tag';
 import { useApp } from '@/contexts/AppContext';
+import { updatePageMeta } from '@/utils/seo';
 
 import campus from '@/public/images/campus.png';
 
@@ -19,6 +20,16 @@ const BlogDetailPage: React.FC = () => {
   const params = useParams();
   const blogId = params.id as string;
   const { state } = useApp();
+
+  // Set dynamic page title based on blog post
+  useEffect(() => {
+    if (blogId) {
+      const post = state.blogPosts.find(p => p.id === blogId);
+      if (post) {
+        updatePageMeta(post.title, post.excerpt || '');
+      }
+    }
+  }, [state.blogPosts, blogId]);
 
   // Increment unique blog read on mount 
   useEffect(() => {

--- a/app/board-apply/page.tsx
+++ b/app/board-apply/page.tsx
@@ -1,10 +1,15 @@
 'use client'
 
+import { useEffect } from 'react';
 import BoardApplicationPage from '@/components/pages/BoardApplicationPage';
 import AdminGate from '@/components/auth/AdminGate';
 import { ErrorBoundaryWrapper } from '@/components/ui/ErrorBoundaryWrapper';
+import { updatePageMeta } from '@/utils/seo';
 
 export default function Page() {
+  useEffect(() => {
+    updatePageMeta('Board Application', 'Apply for the UU AI Society board');
+  }, []);
   return (
     <ErrorBoundaryWrapper>
       <AdminGate>

--- a/app/checkin/page.tsx
+++ b/app/checkin/page.tsx
@@ -10,6 +10,7 @@ import { setAttendanceForUser } from "@/lib/firestore/attendance";
 import AdminGate from "@/components/auth/AdminGate";
 import { getUserProfile } from "@/lib/firestore/users";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { updatePageMeta } from "@/utils/seo";
 
 const CheckinPage: React.FC = () => {
   const searchParams = useSearchParams();
@@ -19,6 +20,10 @@ const CheckinPage: React.FC = () => {
   const [status, setStatus] = useState<"idle" | "working" | "done" | "error">("idle");
   const [message, setMessage] = useState<string>("");
   const [userName, setUserName] = useState<string>("");
+
+  useEffect(() => {
+    updatePageMeta("Event Check-in", "Admin event check-in page");
+  }, []);
 
   useEffect(() => {
     if (!eventId || !scannedUserId) {
@@ -73,9 +78,11 @@ const CheckinPage: React.FC = () => {
               <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
                 Event Check-in
               </h1>
-              <h1 className="text-gray-700 dark:text-gray-300 mb-6 text-xl font-bold">
-                {userName}
-              </h1>
+              {userName && (
+                <h1 className="text-gray-700 dark:text-gray-300 mb-6 text-xl font-bold">
+                  {userName}
+                </h1>
+              )}
               <p className={`mb-6 ${status === "error" ? "text-red-600" : status === "done" ? "text-green-600 dark:text-green-400/80" : "text-gray-700 dark:text-gray-300"}`}>
                 {message || "Processing your check-in..."}
               </p>

--- a/app/confirm/[token]/page.tsx
+++ b/app/confirm/[token]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Card, CardContent, CardHeader } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { confirmRegistrationByToken } from '@/lib/firestore/registrations';
+import { updatePageMeta } from '@/utils/seo';
 
 const ConfirmPage: React.FC = () => {
   const params = useParams();
@@ -13,6 +14,10 @@ const ConfirmPage: React.FC = () => {
   const [status, setStatus] = useState<'idle' | 'loading' | 'done'>('idle');
   const [ok, setOk] = useState<boolean>(false);
   const [message, setMessage] = useState<string>('');
+
+  useEffect(() => {
+    updatePageMeta('Event Confirmation', 'Confirm your event registration');
+  }, []);
 
   useEffect(() => {
     let mounted = true;

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -21,6 +21,7 @@ import { incrementExternalRegistrationClick } from "@/lib/firestore/analytics";
 import { auth } from "@/lib/firebase-client";
 import { getMyRegistrationForEvent } from "@/lib/firestore/registrations";
 import QRCode from "react-qr-code";
+import { updatePageMeta } from "@/utils/seo";
 
 const categoryOptions = [
   { value: "all", label: "All Categories" },
@@ -35,6 +36,16 @@ const EventDetailPage: React.FC = () => {
   const { state } = useApp();
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [hasEligibleRegistration, setHasEligibleRegistration] = useState(false);
+
+  // Set dynamic page title based on event
+  useEffect(() => {
+    if (eventId) {
+      const ev = state.events.find(e => e.id === eventId);
+      if (ev) {
+        updatePageMeta(ev.title, ev.description?.slice(0, 160) || '');
+      }
+    }
+  }, [state.events, eventId]);
 
   // Increment unique event click on mount
   useEffect(() => {

--- a/app/explore/[id]/page.tsx
+++ b/app/explore/[id]/page.tsx
@@ -4,6 +4,22 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
 import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params;
+  if (!id) return { title: "Course Detail" };
+  try {
+    const course = await fetchCourseById(id);
+    if (!course) return { title: "Course Detail" };
+    return {
+      title: course.title || course.code || "Course Detail",
+      description: course.description?.slice(0, 160) || "",
+    };
+  } catch {
+    return { title: "Course Detail" };
+  }
+}
 
 export default async function ExploreDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,14 +1,18 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import LoginModal from '@/components/ui/LoginModal'
+import { updatePageMeta } from '@/utils/seo'
 
 export default function LoginPage() {
   const router = useRouter()
 
+  useEffect(() => {
+    updatePageMeta('Sign In', 'Sign in to your UU AI Society account');
+  }, []);
+
   const after = () => {
-    // Redirect to previous or default
     router.push('/account')
   }
 

--- a/app/my-courses/page.tsx
+++ b/app/my-courses/page.tsx
@@ -205,7 +205,7 @@ export default function MyCoursesPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">My Courses</h1>
           <p className="text-gray-600 dark:text-gray-300 mb-6">Sign in to view your favorite courses and custom categories</p>
-          <Link href="/account">
+          <Link href="/account?returnTo=/my-courses">
             <Button className="bg-[#990000] hover:bg-[#7f0000] text-white">Sign In</Button>
           </Link>
         </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,4 +1,10 @@
 import { PrivacyPage } from '@/components/pages/PrivacyPage';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | UU AI Society',
+  description: 'Privacy policy and GDPR compliance for UU AI Society',
+};
 
 export default function Privacy() {
   return <PrivacyPage />;

--- a/app/projects/course-navigator/page.tsx
+++ b/app/projects/course-navigator/page.tsx
@@ -1,11 +1,16 @@
 'use client';
 
+import { useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/Button';
 import { ArrowRight } from 'lucide-react';
+import { updatePageMeta } from '@/utils/seo';
 
 export default function CourseNavigatorPage() {
+  useEffect(() => {
+    updatePageMeta('Course Navigator', 'AI-powered course recommendations for Uppsala University students');
+  }, []);
   return (
     <div className="min-h-screen pt-18 pb-8 bg-gray-50 dark:bg-gray-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'Explore the innovative projects at UU AI Society',
+};
 
 const projects = [
   {

--- a/app/study-plan/page.tsx
+++ b/app/study-plan/page.tsx
@@ -1,9 +1,12 @@
+import type { Metadata } from "next";
 import React from "react";
-//import { fetchCourses } from "@/lib/courses";
-import { updatePageMeta } from "@/utils/seo";
+
+export const metadata: Metadata = {
+  title: "Study Plan Explorer",
+  description: "Visualize your entire degree pathway",
+};
 
 export default async function StudyPlanPage() {
-    updatePageMeta("Study Plan Explorer", "Visualize your entire degree pathway");
 
     // Server-side fetch
     //const courses = await fetchCourses();


### PR DESCRIPTION
Fixes #53

- Fix empty \<h1\> on /checkin when no userId param
- Add page titles to all 10 pages that were missing them
- Add returnTo param to /my-courses sign-in link