### PR TITLE
Team application portal: apply wizard, admin campaigns, and hardened submission API

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ npm run test:coverage  # Run with coverage report
 
 ### Writing Tests
 
-Create test files anywhere in the project with `.test.ts` or `.test.tsx` suffixes, or in a `__tests__/` directory:
+Create test files in the `__tests__/` directory:
 
 ```tsx
 import { render, screen } from '@testing-library/react'

--- a/__tests__/app/api/apply.test.ts
+++ b/__tests__/app/api/apply.test.ts
@@ -33,10 +33,11 @@ jest.mock('@/lib/auth-config', () => ({
 }))
 
 // Build adminDb mocks for two collections: applicationCampaigns (doc lookup) and others (collections)
+let campaignData: Record<string, unknown> = { status: 'open', teams: ['it', 'development'] }
 const campaignDocRef = createDocRef('spring2026')
 campaignDocRef.get = jest.fn().mockResolvedValue({
   exists: true,
-  data: () => ({ status: 'open', teams: ['it', 'development'] }),
+  data: () => campaignData,
 })
 
 const teamAppsCollection = createCollectionMock()
@@ -46,6 +47,17 @@ const teamAppDocRef = createDocRef('team-app-doc')
 teamAppsCollection.doc = jest.fn(() => teamAppDocRef)
 limitsCollection.doc = jest.fn(() => createDocRef())
 locksCollection.doc = jest.fn(() => createDocRef())
+
+// campaignQuestions: queryable by campaignId; docs configurable per test
+let questionsData: { id: string; question: string; required?: boolean }[] = []
+const questionsCollection = createCollectionMock()
+questionsCollection.get = jest.fn().mockImplementation(() =>
+  Promise.resolve({
+    empty: questionsData.length === 0,
+    docs: questionsData.map((q) => ({ id: q.id, data: () => q })),
+    size: questionsData.length,
+  }),
+)
 
 jest.mock('@/lib/firebase-admin', () => ({
   adminDb: {
@@ -58,6 +70,7 @@ jest.mock('@/lib/firebase-admin', () => ({
       if (name === 'teamApplications') return teamAppsCollection
       if (name === 'applicationUserLimits') return limitsCollection
       if (name === 'applicationCampaignLocks') return locksCollection
+      if (name === 'campaignQuestions') return questionsCollection
       return createCollectionMock()
     }),
     runTransaction: (...args: unknown[]) => mockRunTransaction(...args),
@@ -66,14 +79,31 @@ jest.mock('@/lib/firebase-admin', () => ({
 
 type MockTx = { get: jest.Mock; set: jest.Mock; delete: jest.Mock }
 
+let lastTx: MockTx | null = null
+
+function lastApplicationPayload(): Record<string, unknown> | null {
+  if (!lastTx) return null
+  for (const call of lastTx.set.mock.calls) {
+    const arg = call[1] as Record<string, unknown> | undefined
+    if (arg && typeof arg === 'object' && 'applicationType' in arg) {
+      return arg
+    }
+  }
+  return null
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
+  campaignData = { status: 'open', teams: ['it', 'development'] }
+  questionsData = []
+  lastTx = null
   mockRunTransaction.mockImplementation(async (cb: (tx: MockTx) => Promise<void>) => {
     const tx: MockTx = {
       get: jest.fn().mockResolvedValue({ exists: false, data: () => null }),
       set: jest.fn().mockResolvedValue(undefined),
       delete: jest.fn().mockResolvedValue(undefined),
     }
+    lastTx = tx
     await cb(tx)
   })
 })
@@ -216,7 +246,7 @@ describe('POST /api/apply', () => {
       const body = await res.json()
 
       expect(res.status).toBe(400)
-      expect(body.error).toMatch(/scheme|invalid/i)
+      expect(body.error).toMatch(/linkedin/i)
     })
 
     it('returns 400 when weekly hours exceeds max', async () => {
@@ -265,6 +295,213 @@ describe('POST /api/apply', () => {
       expect(body.name).toBe('Alice')
       expect(body.campaignId).toBe('spring2026')
       expect(body.id).toBeDefined()
+    })
+  })
+
+  describe('security hardening', () => {
+    it('stores the verified uid on the application', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('linkedin', 'https://linkedin.com/in/alice')
+      formData.set('motivation', 'I want to contribute to the AI community.')
+      formData.set('agree', 'true')
+      formData.set('teamRanking', JSON.stringify(['it']))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(200)
+      expect(lastApplicationPayload()?.uid).toBe('user1')
+    })
+
+    it('drops disabled standard fields from the stored application', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email'] }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+      formData.set('teamRanking', JSON.stringify(['it']))
+      formData.set('weeklyHours', '5')
+      formData.set('interests', JSON.stringify(['robotics']))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(200)
+      const payload = lastApplicationPayload()
+      expect(payload?.teamRanking).toEqual([])
+      expect(payload?.weeklyHours).toBe(0)
+      expect(payload?.interests).toEqual([])
+    })
+
+    it('rejects a submission missing a required custom question', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email'] }
+      questionsData = [{ id: 'q1', question: 'What is your favourite project?', required: true }]
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+      formData.set('customAnswers', JSON.stringify({}))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/favourite project.*required|required.*favourite project/i)
+    })
+
+    it('accepts a submission when all required custom questions are answered', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email'] }
+      questionsData = [{ id: 'q1', question: 'What is your favourite project?', required: true }]
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+      formData.set('customAnswers', JSON.stringify({ q1: 'My capstone project' }))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(200)
+    })
+
+    it('rejects a submission when the campaign deadline has passed', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], deadline: '2020-01-01' }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/no longer/i)
+    })
+
+    it('accepts a submission when the campaign deadline is in the future', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], deadline: '2099-01-01' }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('linkedin', 'https://linkedin.com/in/alice')
+      formData.set('motivation', 'I want to contribute to the AI community.')
+      formData.set('agree', 'true')
+      formData.set('teamRanking', JSON.stringify(['it']))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('enabledStandardFields', () => {
+    it('accepts a submission without motivation/linkedin when those fields are disabled', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email'] }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+      formData.set('weeklyHours', '5')
+      formData.set('interests', JSON.stringify(['robotics']))
+      formData.set('teamRanking', JSON.stringify(['it']))
+      formData.set('customAnswers', JSON.stringify({}))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(200)
+    })
+
+    it('rejects a submission missing motivation when motivation is enabled', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email', 'motivation'] }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/motivation/i)
+    })
+
+    it('rejects a submission with teamRanking enabled but empty ranking', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email', 'teamRanking'] }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+      formData.set('teamRanking', JSON.stringify([]))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/team|preference/i)
+    })
+
+    it('still enforces max length on a disabled motivation field', async () => {
+      campaignData = { status: 'open', teams: ['it', 'development'], enabledStandardFields: ['name', 'email'] }
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('agree', 'true')
+      formData.set('motivation', 'x'.repeat(2001))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/motivation/i)
     })
   })
 })

--- a/__tests__/app/api/apply.test.ts
+++ b/__tests__/app/api/apply.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration test for POST /api/apply
+ *
+ * Tests request/response logic with mocked Firebase dependencies.
+ */
+
+import { createAuthMocks, createCollectionMock, createDocRef } from '@/__tests__/helpers/mocks'
+
+const mockRunTransaction = jest.fn()
+const { mockGetTokens, authEdgeFactory } = createAuthMocks()
+
+jest.mock('next-firebase-auth-edge', () => authEdgeFactory)
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = { serverTimestamp: () => ({ _method: 'serverTimestamp' }) }
+  const firestoreFn = () => ({ runTransaction: (...args: unknown[]) => mockRunTransaction(...args) }) as unknown
+  ;(firestoreFn as { FieldValue: typeof FieldValue }).FieldValue = FieldValue
+  return {
+    firestore: firestoreFn as typeof import('firebase-admin').firestore & { FieldValue: typeof FieldValue },
+    storage: () => ({
+      bucket: () => ({
+        file: () => ({
+          save: jest.fn().mockResolvedValue(undefined),
+          getSignedUrl: jest.fn().mockResolvedValue(['http://signed.url']),
+        }),
+      }),
+    }),
+  }
+})
+
+jest.mock('@/lib/auth-config', () => ({
+  authConfig: { apiKey: 'test', serviceAccount: {} },
+}))
+
+// Build adminDb mocks for two collections: applicationCampaigns (doc lookup) and others (collections)
+const campaignDocRef = createDocRef('spring2026')
+campaignDocRef.get = jest.fn().mockResolvedValue({
+  exists: true,
+  data: () => ({ status: 'open', teams: ['it', 'development'] }),
+})
+
+const teamAppsCollection = createCollectionMock()
+const limitsCollection = createCollectionMock()
+const locksCollection = createCollectionMock()
+const teamAppDocRef = createDocRef('team-app-doc')
+teamAppsCollection.doc = jest.fn(() => teamAppDocRef)
+limitsCollection.doc = jest.fn(() => createDocRef())
+locksCollection.doc = jest.fn(() => createDocRef())
+
+jest.mock('@/lib/firebase-admin', () => ({
+  adminDb: {
+    collection: jest.fn((name: string) => {
+      if (name === 'applicationCampaigns') {
+        const c = createCollectionMock()
+        c.doc = jest.fn(() => campaignDocRef)
+        return c
+      }
+      if (name === 'teamApplications') return teamAppsCollection
+      if (name === 'applicationUserLimits') return limitsCollection
+      if (name === 'applicationCampaignLocks') return locksCollection
+      return createCollectionMock()
+    }),
+    runTransaction: (...args: unknown[]) => mockRunTransaction(...args),
+  },
+}))
+
+type MockTx = { get: jest.Mock; set: jest.Mock; delete: jest.Mock }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockRunTransaction.mockImplementation(async (cb: (tx: MockTx) => Promise<void>) => {
+    const tx: MockTx = {
+      get: jest.fn().mockResolvedValue({ exists: false, data: () => null }),
+      set: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    }
+    await cb(tx)
+  })
+})
+
+describe('POST /api/apply', () => {
+  describe('authentication', () => {
+    it('returns 401 when no auth token', async () => {
+      mockGetTokens.mockResolvedValue(null)
+
+      const { POST } = await import('@/app/api/apply/route')
+      const req = new Request('http://localhost/api/apply', { method: 'POST' })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error).toMatch(/sign in/i)
+    })
+  })
+
+  describe('validation', () => {
+    it('returns 400 when campaignId is missing', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('name', 'Alice')
+      formData.set('email', 'a@b.com')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/campaign/i)
+    })
+
+    it('returns 400 when name is missing', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('email', 'a@b.com')
+      formData.set('motivation', 'I want to join.')
+      formData.set('linkedin', 'https://linkedin.com/in/x')
+      formData.set('agree', 'true')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/name|email/i)
+    })
+
+    it('returns 400 when motivation is missing', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'a@b.com')
+      formData.set('linkedin', 'https://linkedin.com/in/x')
+      formData.set('agree', 'true')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/motivation/i)
+    })
+
+    it('returns 400 when agreement is missing', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'a@b.com')
+      formData.set('linkedin', 'https://linkedin.com/in/x')
+      formData.set('motivation', 'I want to join.')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/agreement/i)
+    })
+
+    it('returns 400 when linkedin is missing', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'a@b.com')
+      formData.set('motivation', 'I want to contribute to the AI community very actively.')
+      formData.set('agree', 'true')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/linkedin/i)
+    })
+
+    it('returns 400 when name exceeds max length', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'A'.repeat(101))
+      formData.set('email', 'a@b.com')
+      formData.set('linkedin', 'https://linkedin.com/in/x')
+      formData.set('motivation', 'I want to join.')
+      formData.set('agree', 'true')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/name.*100|100.*name/i)
+    })
+
+    it('returns 400 when linkedin uses javascript: scheme', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'a@b.com')
+      formData.set('linkedin', 'javascript:alert(1)')
+      formData.set('motivation', 'I want to contribute to the AI community very actively.')
+      formData.set('agree', 'true')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/scheme|invalid/i)
+    })
+
+    it('returns 400 when weekly hours exceeds max', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'a@b.com')
+      formData.set('linkedin', 'https://linkedin.com/in/x')
+      formData.set('motivation', 'I want to contribute to the AI community very actively.')
+      formData.set('agree', 'true')
+      formData.set('weeklyHours', '999')
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toMatch(/hours|between/i)
+    })
+  })
+
+  describe('successful submission', () => {
+    it('writes application and returns 200', async () => {
+      mockGetTokens.mockResolvedValue({ decodedToken: { uid: 'user1' } })
+
+      const { POST } = await import('@/app/api/apply/route')
+      const formData = new FormData()
+      formData.set('campaignId', 'spring2026')
+      formData.set('name', 'Alice')
+      formData.set('email', 'alice@test.com')
+      formData.set('linkedin', 'https://linkedin.com/in/alice')
+      formData.set('motivation', 'I want to contribute to the AI community.')
+      formData.set('agree', 'true')
+      formData.set('weeklyHours', '5')
+      formData.set('interests', JSON.stringify(['robotics', 'nlp']))
+      formData.set('teamRanking', JSON.stringify(['it', 'development']))
+      formData.set('customAnswers', JSON.stringify({}))
+
+      const req = new Request('http://localhost/api/apply', { method: 'POST', body: formData })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.name).toBe('Alice')
+      expect(body.campaignId).toBe('spring2026')
+      expect(body.id).toBeDefined()
+    })
+  })
+})

--- a/__tests__/app/pages/team-application-page.test.tsx
+++ b/__tests__/app/pages/team-application-page.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import TeamApplicationPage from '@/components/pages/TeamApplicationPage'
+import { defaultAppState } from '@/__tests__/helpers/fixtures'
+import type { ApplicationCampaign } from '@/types'
+
+const mockUseApp = jest.fn()
+const mockNotify = jest.fn()
+
+jest.mock('@/contexts/AppContext', () => ({
+  useApp: () => mockUseApp(),
+  AppProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock('@/components/ui/Notifications', () => ({
+  useNotify: () => ({ notify: mockNotify }),
+}))
+
+jest.mock('@/lib/firebase-client', () => ({
+  auth: { onAuthStateChanged: (cb: (u: unknown) => void) => { cb(null); return jest.fn(); } },
+}))
+
+jest.mock('@/lib/firestore/users', () => ({
+  getUserProfile: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('@/lib/firestore/campaignQuestions', () => ({
+  subscribeToCampaignQuestions: jest.fn(() => jest.fn()),
+}))
+
+const sampleCampaign: ApplicationCampaign = {
+  id: 'spring2026',
+  title: 'Spring 2026 Recruitment',
+  subtitle: 'UU AI Society — Spring 2026',
+  description: 'Main yearly recruitment drive for all society teams.',
+  deadline: '2026-05-10',
+  status: 'open',
+  teams: ['it', 'development', 'growth'],
+  enabledStandardFields: ['name', 'email', 'gender', 'university', 'program'],
+}
+
+describe('TeamApplicationPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows loading state when no campaigns', () => {
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    render(<TeamApplicationPage />)
+    expect(screen.getByText('Loading campaigns…')).toBeInTheDocument()
+  })
+
+  it('shows no active campaigns message when only closed/draft campaigns exist', () => {
+    mockUseApp.mockReturnValue({
+      state: {
+        ...defaultAppState,
+        campaigns: [{ ...sampleCampaign, status: 'closed' }],
+      },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    expect(screen.getByText('No active campaigns')).toBeInTheDocument()
+  })
+
+  it('renders hero with campaign title and overview', () => {
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [sampleCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    expect(screen.getByText('Spring 2026 Recruitment')).toBeInTheDocument()
+    expect(screen.getByText(/We are looking for passionate students/)).toBeInTheDocument()
+    expect(screen.getByText('Our Teams')).toBeInTheDocument()
+  })
+
+  it('shows team cards from campaign teams', () => {
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [sampleCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    expect(screen.getByText('IT')).toBeInTheDocument()
+    expect(screen.getByText('Development')).toBeInTheDocument()
+    expect(screen.getByText('Growth')).toBeInTheDocument()
+  })
+
+  it('navigates to profile step on Continue click', () => {
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [sampleCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    fireEvent.click(screen.getByText('Continue'))
+    // "Your Profile" appears in step-nav as well as h2; match the h2 heading specifically
+    expect(screen.getByRole('heading', { name: 'Your Profile', level: 2 })).toBeInTheDocument()
+  })
+
+  it('shows team selection step heading after navigating to step 4', () => {
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [sampleCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    // Step 0 -> 1 (Overview -> Profile)
+    fireEvent.click(screen.getByText('Continue'))
+    const nameInput = screen.getByLabelText(/Full name/i)
+    const emailInput = screen.getByLabelText(/^Email/i)
+    fireEvent.change(nameInput, { target: { value: 'Alex' } })
+    fireEvent.change(emailInput, { target: { value: 'alex@test.com' } })
+    // Step 1 -> 2 (Profile -> Experience)
+    fireEvent.click(screen.getByText('Continue'))
+    // On step 2 (Experience), set linkedin and select an area of interest to enable Continue
+    fireEvent.change(screen.getByLabelText(/LinkedIn URL/i), { target: { value: 'https://linkedin.com/in/alice' } })
+    fireEvent.click(screen.getByLabelText('Robotics'))
+    fireEvent.click(screen.getByText('Continue'))
+    expect(screen.getByText('Draggable Team Selection')).toBeInTheDocument()
+    expect(screen.getByText('Weekly Availability')).toBeInTheDocument()
+    expect(screen.getByText('Personal motivation')).toBeInTheDocument()
+  })
+
+  it('renders review step after completing all steps', () => {
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [sampleCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    fireEvent.click(screen.getByText('Continue'))
+    fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
+    fireEvent.change(screen.getByLabelText(/^Email/i), { target: { value: 'alex@test.com' } })
+    fireEvent.click(screen.getByText('Continue'))
+    fireEvent.change(screen.getByLabelText(/LinkedIn URL/i), { target: { value: 'https://linkedin.com/in/alice' } })
+    fireEvent.click(screen.getByLabelText('Robotics'))
+    fireEvent.click(screen.getByText('Continue'))
+    // Step 3 (Team Selection): add a team so Continue is enabled (canNext requires motivation + ranking >= 1)
+    const itButton = screen.getByRole('button', { name: /^IT/i })
+    fireEvent.click(itButton)
+    // Fill motivation so Continue is enabled
+    fireEvent.change(screen.getByPlaceholderText(/Tell us why you want to join/), { target: { value: 'I am excited to contribute to AI.' } })
+    fireEvent.click(screen.getByText('Continue'))
+    expect(screen.getByRole('heading', { name: /Review & Submit/i, level: 2 })).toBeInTheDocument()
+  })
+})

--- a/__tests__/app/pages/team-application-page.test.tsx
+++ b/__tests__/app/pages/team-application-page.test.tsx
@@ -5,6 +5,7 @@ import type { ApplicationCampaign } from '@/types'
 
 const mockUseApp = jest.fn()
 const mockNotify = jest.fn()
+const mockSubscribeToCampaignQuestions = jest.fn(() => jest.fn())
 
 jest.mock('@/contexts/AppContext', () => ({
   useApp: () => mockUseApp(),
@@ -24,7 +25,7 @@ jest.mock('@/lib/firestore/users', () => ({
 }))
 
 jest.mock('@/lib/firestore/campaignQuestions', () => ({
-  subscribeToCampaignQuestions: jest.fn(() => jest.fn()),
+  subscribeToCampaignQuestions: (...args: unknown[]) => mockSubscribeToCampaignQuestions(...args),
 }))
 
 const sampleCampaign: ApplicationCampaign = {
@@ -32,15 +33,19 @@ const sampleCampaign: ApplicationCampaign = {
   title: 'Spring 2026 Recruitment',
   subtitle: 'UU AI Society — Spring 2026',
   description: 'Main yearly recruitment drive for all society teams.',
-  deadline: '2026-05-10',
+  deadline: '2099-05-10',
   status: 'open',
   teams: ['it', 'development', 'growth'],
-  enabledStandardFields: ['name', 'email', 'gender', 'university', 'program'],
+  enabledStandardFields: [
+    'name', 'email', 'gender', 'university', 'program', 'graduationYear',
+    'linkedin', 'resume', 'interests', 'teamRanking', 'weeklyHours', 'motivation',
+  ],
 }
 
 describe('TeamApplicationPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSubscribeToCampaignQuestions.mockImplementation(() => jest.fn())
   })
 
   it('shows loading state when no campaigns', () => {
@@ -53,6 +58,7 @@ describe('TeamApplicationPage', () => {
     mockUseApp.mockReturnValue({
       state: {
         ...defaultAppState,
+        campaignsLoaded: true,
         campaigns: [{ ...sampleCampaign, status: 'closed' }],
       },
       dispatch: jest.fn(),
@@ -137,5 +143,64 @@ describe('TeamApplicationPage', () => {
     fireEvent.change(screen.getByPlaceholderText(/Tell us why you want to join/), { target: { value: 'I am excited to contribute to AI.' } })
     fireEvent.click(screen.getByText('Continue'))
     expect(screen.getByRole('heading', { name: /Review & Submit/i, level: 2 })).toBeInTheDocument()
+  })
+
+  it('hides standard fields that the campaign has disabled', () => {
+    const limitedCampaign: ApplicationCampaign = {
+      ...sampleCampaign,
+      enabledStandardFields: ['name', 'email'],
+    }
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [limitedCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    fireEvent.click(screen.getByText('Continue'))
+    // Name/email still render, but disabled fields (LinkedIn, etc.) do not
+    expect(screen.getByLabelText(/Full name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^Email/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/LinkedIn URL/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Areas of Interest')).not.toBeInTheDocument()
+    // Continue is enabled without filling the disabled LinkedIn/interests fields
+    fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
+    fireEvent.change(screen.getByLabelText(/^Email/i), { target: { value: 'alex@test.com' } })
+    fireEvent.click(screen.getByText('Continue'))
+    fireEvent.click(screen.getByText('Continue'))
+    expect(screen.getByRole('heading', { name: /Team Selection/i, level: 2 })).toBeInTheDocument()
+  })
+
+  it('shows applications closed when the campaign deadline has passed', () => {
+    mockUseApp.mockReturnValue({
+      state: {
+        ...defaultAppState,
+        campaignsLoaded: true,
+        campaigns: [{ ...sampleCampaign, deadline: '2020-01-01' }],
+      },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    expect(screen.getByText('Applications Closed')).toBeInTheDocument()
+    expect(screen.queryByText('Continue')).not.toBeInTheDocument()
+  })
+
+  it('blocks advancing when a required custom question is unanswered', () => {
+    mockSubscribeToCampaignQuestions.mockImplementation((_id: string, cb: (qs: unknown[]) => void) => {
+      cb([{ id: 'q1', question: 'Why do you want to join?', required: true, type: 'textarea' }])
+      return jest.fn()
+    })
+    mockUseApp.mockReturnValue({
+      state: { ...defaultAppState, campaigns: [sampleCampaign] },
+      dispatch: jest.fn(),
+    })
+    render(<TeamApplicationPage />)
+    fireEvent.click(screen.getByText('Continue'))
+    fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
+    fireEvent.change(screen.getByLabelText(/^Email/i), { target: { value: 'alex@test.com' } })
+    fireEvent.click(screen.getByText('Continue'))
+    fireEvent.change(screen.getByLabelText(/LinkedIn URL/i), { target: { value: 'https://linkedin.com/in/alice' } })
+    fireEvent.click(screen.getByLabelText('Robotics'))
+    expect(screen.getByRole('button', { name: /Continue/i })).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/Why do you want to join/), { target: { value: 'I love AI.' } })
+    expect(screen.getByRole('button', { name: /Continue/i })).toBeEnabled()
   })
 })

--- a/__tests__/components/admin/applications-tab.test.tsx
+++ b/__tests__/components/admin/applications-tab.test.tsx
@@ -2,6 +2,10 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import ApplicationsTab from '@/components/pages/admin/tabs/ApplicationsTab'
 import type { ApplicationCampaign, TeamApplication } from '@/types'
 
+jest.mock('@/lib/firestore/campaignQuestions', () => ({
+  subscribeToCampaignQuestions: jest.fn(() => jest.fn()),
+}))
+
 const sampleCampaign: ApplicationCampaign = {
   id: 'spring2026',
   title: 'Spring 2026 Recruitment',
@@ -36,6 +40,7 @@ const baseProps = (overrides: Partial<React.ComponentProps<typeof ApplicationsTa
   onAddCampaign: jest.fn(),
   onEditCampaign: jest.fn(),
   onDeleteCampaign: jest.fn(),
+  onUpdateCampaignStatus: jest.fn(),
   onDeleteApplication: jest.fn(),
   ...overrides,
 })
@@ -109,6 +114,14 @@ describe('ApplicationsTab', () => {
     expect(screen.getByText('Delete campaign?')).toBeInTheDocument()
     fireEvent.click(screen.getByText('Delete'))
     expect(onDeleteCampaign).toHaveBeenCalledWith('spring2026')
+  })
+
+  it('toggles campaign status via the segmented control', () => {
+    const onUpdateCampaignStatus = jest.fn()
+    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign], onUpdateCampaignStatus })} />)
+    // The card's status toggle has a "Draft" button (the filter tab says "Draft 0")
+    fireEvent.click(screen.getByRole('button', { name: 'Draft' }))
+    expect(onUpdateCampaignStatus).toHaveBeenCalledWith('spring2026', 'draft')
   })
 
   it('expands a submission to show motivation on click', () => {

--- a/__tests__/components/admin/applications-tab.test.tsx
+++ b/__tests__/components/admin/applications-tab.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import ApplicationsTab from '@/components/pages/admin/tabs/ApplicationsTab'
+import type { ApplicationCampaign, TeamApplication } from '@/types'
+
+const sampleCampaign: ApplicationCampaign = {
+  id: 'spring2026',
+  title: 'Spring 2026 Recruitment',
+  subtitle: 'UU AI Society — Spring 2026',
+  description: 'Main yearly drive.',
+  deadline: '2026-05-10',
+  status: 'open',
+  teams: ['it', 'development'],
+  enabledStandardFields: ['name', 'email'],
+}
+
+const sampleSubmission: TeamApplication = {
+  id: 'sub-1',
+  campaignId: 'spring2026',
+  name: 'Alice Doe',
+  email: 'alice@test.com',
+  program: 'Data Science (MSc)',
+  graduationYear: '2027',
+  linkedin: 'https://linkedin.com/in/alice',
+  interests: ['robotics'],
+  teamRanking: ['it', 'development'],
+  weeklyHours: 8,
+  motivation: 'I want to contribute.',
+  customAnswers: {},
+  agree: true,
+  createdAt: '2026-04-01',
+}
+
+const baseProps = (overrides: Partial<React.ComponentProps<typeof ApplicationsTab>> = {}) => ({
+  campaigns: [] as ApplicationCampaign[],
+  applications: [] as TeamApplication[],
+  onAddCampaign: jest.fn(),
+  onEditCampaign: jest.fn(),
+  onDeleteCampaign: jest.fn(),
+  onDeleteApplication: jest.fn(),
+  ...overrides,
+})
+
+describe('ApplicationsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders header and New campaign button', () => {
+    render(<ApplicationsTab {...baseProps()} />)
+    expect(screen.getByText('Application Campaigns')).toBeInTheDocument()
+    expect(screen.getByText('New campaign')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no campaigns match filter', () => {
+    render(<ApplicationsTab {...baseProps({ campaigns: [] })} />)
+    expect(screen.getByText(/No campaigns with status/i)).toBeInTheDocument()
+  })
+
+  it('renders campaign cards with status badges and actions', () => {
+    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign] })} />)
+    expect(screen.getByText('Spring 2026 Recruitment')).toBeInTheDocument()
+    // Status badge appears as Tag; filter tab button also says "Open" — match the badge (text-sm size on Tag).
+    const openMatches = screen.getAllByText('Open')
+    expect(openMatches.length).toBeGreaterThan(0)
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+  })
+
+  it('filters by Open tab', () => {
+    render(<ApplicationsTab {...baseProps({ campaigns: [
+      sampleCampaign,
+      { ...sampleCampaign, id: 'closed-one', status: 'closed', title: 'Closed Campaign' },
+    ] })} />)
+    // Click the "Open" filter tab (filter buttons have border-b-2 class inline)
+    const openButtons = screen.getAllByRole('button', { name: /^Open/i })
+    fireEvent.click(openButtons.find(b => b.tagName === 'BUTTON')!)
+    expect(screen.getByText('Spring 2026 Recruitment')).toBeInTheDocument()
+    expect(screen.queryByText('Closed Campaign')).not.toBeInTheDocument()
+  })
+
+  it('switches to submissions view on View submissions click', () => {
+    render(<ApplicationsTab {...baseProps({
+      campaigns: [sampleCampaign],
+      applications: [sampleSubmission],
+    })} />)
+    fireEvent.click(screen.getByText('View submissions'))
+    expect(screen.getByText('Submissions: Spring 2026 Recruitment')).toBeInTheDocument()
+    expect(screen.getByText('Alice Doe')).toBeInTheDocument()
+  })
+
+  it('calls onAddCampaign when New campaign is clicked', () => {
+    const onAddCampaign = jest.fn()
+    render(<ApplicationsTab {...baseProps({ onAddCampaign })} />)
+    fireEvent.click(screen.getByText('New campaign'))
+    expect(onAddCampaign).toHaveBeenCalled()
+  })
+
+  it('calls onEditCampaign when Edit is clicked', () => {
+    const onEditCampaign = jest.fn()
+    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign], onEditCampaign })} />)
+    fireEvent.click(screen.getByText('Edit'))
+    expect(onEditCampaign).toHaveBeenCalledWith(sampleCampaign)
+  })
+
+  it('opens confirm modal when delete campaign clicked and confirms delete', () => {
+    const onDeleteCampaign = jest.fn()
+    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign], onDeleteCampaign })} />)
+    // Click the destructive delete button (Trash2 icon-only button)
+    fireEvent.click(screen.getByRole('button', { name: /delete campaign/i }))
+    expect(screen.getByText('Delete campaign?')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Delete'))
+    expect(onDeleteCampaign).toHaveBeenCalledWith('spring2026')
+  })
+
+  it('expands a submission to show motivation on click', () => {
+    render(<ApplicationsTab {...baseProps({
+      campaigns: [sampleCampaign],
+      applications: [sampleSubmission],
+    })} />)
+    fireEvent.click(screen.getByText('View submissions'))
+    fireEvent.click(screen.getByText('Alice Doe'))
+    expect(screen.getByText('I want to contribute.')).toBeInTheDocument()
+  })
+
+  it('Back button returns to campaigns view', () => {
+    render(<ApplicationsTab {...baseProps({
+      campaigns: [sampleCampaign],
+      applications: [sampleSubmission],
+    })} />)
+    fireEvent.click(screen.getByText('View submissions'))
+    fireEvent.click(screen.getByText('Back to campaigns'))
+    expect(screen.getByText('Application Campaigns')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/admin/campaign-builder-modal.test.tsx
+++ b/__tests__/components/admin/campaign-builder-modal.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import CampaignBuilderModal from '@/components/pages/admin/modals/CampaignBuilderModal'
+import { getCampaignQuestions } from '@/lib/firestore/campaignQuestions'
+import type { ApplicationCampaign } from '@/types'
+
+jest.mock('@/lib/firestore/campaignQuestions', () => ({
+  getCampaignQuestions: jest.fn(),
+  addCampaignQuestion: jest.fn(),
+  updateCampaignQuestion: jest.fn(),
+  deleteCampaignQuestion: jest.fn(),
+  deleteCampaignQuestionsByCampaign: jest.fn(),
+}))
+
+jest.mock('@/components/ui/Notifications', () => ({
+  useNotify: () => ({ notify: jest.fn() }),
+}))
+
+const mockGetQuestions = getCampaignQuestions as jest.Mock
+
+const campaign: ApplicationCampaign = {
+  id: 'c1',
+  title: 'Spring 2026 Recruitment',
+  subtitle: 'UU AI Society — Spring 2026',
+  description: 'Main yearly drive.',
+  deadline: '2099-01-01',
+  status: 'draft',
+  teams: ['it', 'development'],
+  enabledStandardFields: ['name', 'email'],
+}
+
+const baseProps = (overrides: Partial<React.ComponentProps<typeof CampaignBuilderModal>> = {}) => ({
+  open: true,
+  campaign,
+  isNew: false,
+  onClose: jest.fn(),
+  onSaveCampaign: jest.fn(),
+  ...overrides,
+})
+
+describe('CampaignBuilderModal options editor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetQuestions.mockResolvedValue([
+      { id: 'q1', campaignId: 'c1', question: 'Favorite team?', type: 'select', options: ['IT', 'Dev'], required: false, order: 0 },
+    ])
+  })
+
+  it('lists existing options for a select question', async () => {
+    render(<CampaignBuilderModal {...baseProps()} />)
+    fireEvent.click(await screen.findByRole('button', { name: /Options \(2\)/ }))
+    expect(screen.getByDisplayValue('IT')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Dev')).toBeInTheDocument()
+  })
+
+  it('creates and edits a new option via the Create new option button', async () => {
+    render(<CampaignBuilderModal {...baseProps()} />)
+    fireEvent.click(await screen.findByRole('button', { name: /Options \(2\)/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Create new option/i }))
+    const newInput = screen.getByPlaceholderText('Option 3')
+    fireEvent.change(newInput, { target: { value: 'Growth' } })
+    expect(screen.getByDisplayValue('Growth')).toBeInTheDocument()
+  })
+
+  it('removes an option', async () => {
+    render(<CampaignBuilderModal {...baseProps()} />)
+    fireEvent.click(await screen.findByRole('button', { name: /Options \(2\)/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove option 1' }))
+    expect(screen.queryByDisplayValue('IT')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('Dev')).toBeInTheDocument()
+  })
+
+  it('updates the options count label as options are added', async () => {
+    render(<CampaignBuilderModal {...baseProps()} />)
+    const toggle = await screen.findByRole('button', { name: /Options \(2\)/ })
+    fireEvent.click(toggle)
+    fireEvent.click(screen.getByRole('button', { name: /Create new option/i }))
+    // Collapse and re-expand: count should still be 2 while the new option is empty
+    fireEvent.click(screen.getByRole('button', { name: /Hide options/i }))
+    expect(screen.getByRole('button', { name: /Options \(2\)/ })).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/layout/header.test.tsx
+++ b/__tests__/components/layout/header.test.tsx
@@ -36,6 +36,7 @@ describe('Header', () => {
   beforeEach(() => {
     g.__mockPathname = '/events'
     mockAdminState()
+    global.__setAppState?.(null)
   })
 
   describe('navigation links', () => {
@@ -46,6 +47,15 @@ describe('Header', () => {
       expect(screen.getAllByText('Job board').length).toBe(2)
       expect(screen.getAllByText('About').length).toBe(2)
       expect(screen.getAllByText('Contact').length).toBe(2)
+    })
+
+    it('renders Apply as a distinct CTA in desktop and mobile nav', () => {
+      render(<Header />)
+      const applyLinks = screen.getAllByRole('link', { name: 'Apply' })
+      expect(applyLinks.length).toBe(2)
+      applyLinks.forEach((link) => expect(link).toHaveAttribute('href', '/apply/team'))
+      // CTA uses a solid background to stand out from regular nav links
+      expect(applyLinks[0].className).toMatch(/bg-red-600|bg-white/)
     })
 
     it('renders register and login links when not authenticated', () => {
@@ -68,6 +78,32 @@ describe('Header', () => {
     it('shows spacer on non-homepage', () => {
       const { container } = render(<Header />)
       expect(container.querySelector('div.h-\\[100px\\]')).toBeInTheDocument()
+    })
+  })
+
+  describe('Apply CTA visibility', () => {
+    it('hides Apply when campaigns are loaded and none are open', () => {
+      global.__setAppState?.({
+        campaigns: [{ id: 'c1', status: 'closed', title: 'Closed', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
+        campaignsLoaded: true,
+      })
+      render(<Header />)
+      expect(screen.queryByRole('link', { name: 'Apply' })).not.toBeInTheDocument()
+    })
+
+    it('shows Apply when an open campaign exists', () => {
+      global.__setAppState?.({
+        campaigns: [{ id: 'c1', status: 'open', title: 'Open', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
+        campaignsLoaded: true,
+      })
+      render(<Header />)
+      expect(screen.getAllByRole('link', { name: 'Apply' }).length).toBe(2)
+    })
+
+    it('shows Apply while campaigns are still loading', () => {
+      global.__setAppState?.(null)
+      render(<Header />)
+      expect(screen.getAllByRole('link', { name: 'Apply' }).length).toBe(2)
     })
   })
 

--- a/__tests__/components/ui/team-ranker.test.tsx
+++ b/__tests__/components/ui/team-ranker.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import TeamRanker, { TeamRankEntry } from '@/components/ui/TeamRanker'
+
+const TEAM_NAMES: Record<string, string> = {
+  it: 'IT',
+  development: 'Development',
+  growth: 'Growth',
+}
+
+function mockDataTransfer() {
+  return {
+    setData: jest.fn(),
+    effectAllowed: '',
+    dropEffect: '',
+  }
+}
+
+function renderRanker(onChange: jest.Mock) {
+  const ranking: TeamRankEntry[] = [
+    { id: 'it', name: 'IT' },
+    { id: 'development', name: 'Development' },
+  ]
+  render(
+    <TeamRanker
+      ranking={ranking}
+      onChange={onChange}
+      availableTeamIds={['it', 'development', 'growth']}
+      teamName={(id) => TEAM_NAMES[id] || id}
+      customTeam=""
+      onCustomTeamChange={jest.fn()}
+    />
+  )
+}
+
+describe('TeamRanker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the selection hint', () => {
+    const onChange = jest.fn()
+    renderRanker(onChange)
+    expect(screen.getByText(/Click teams to add or remove them/)).toBeInTheDocument()
+  })
+
+  it('inserts a team dragged from Available at the drop position in the ranking', () => {
+    const onChange = jest.fn()
+    renderRanker(onChange)
+
+    // Drag "Growth" from the Available zone and drop it on the top preference item (IT)
+    fireEvent.dragStart(screen.getByRole('button', { name: /Growth/i }), { dataTransfer: mockDataTransfer() })
+    const firstPref = screen.getByText('IT').closest('[draggable]') as HTMLElement
+    fireEvent.dragOver(firstPref, { dataTransfer: mockDataTransfer() })
+    fireEvent.drop(firstPref, { dataTransfer: mockDataTransfer() })
+
+    // Growth should be ranked #1, and NOT also appended at the end
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith([
+      { id: 'growth', name: 'Growth' },
+      { id: 'it', name: 'IT' },
+      { id: 'development', name: 'Development' },
+    ])
+  })
+
+  it('removes a team dropped back into the Available zone', () => {
+    const onChange = jest.fn()
+    renderRanker(onChange)
+
+    // Drag the first preference item (IT) back to Available
+    const firstPref = screen.getByText('IT').closest('[draggable]') as HTMLElement
+    fireEvent.dragStart(firstPref, { dataTransfer: mockDataTransfer() })
+    const availableZone = screen.getByRole('button', { name: /Growth/i }).closest('[class*="border"]') as HTMLElement
+    fireEvent.drop(availableZone, { dataTransfer: mockDataTransfer() })
+
+    expect(onChange).toHaveBeenCalledWith([
+      { id: 'development', name: 'Development' },
+    ])
+  })
+})

--- a/__tests__/contexts/AppContext.test.tsx
+++ b/__tests__/contexts/AppContext.test.tsx
@@ -98,6 +98,7 @@ import {
   subscribeToPositions, addPosition, updatePosition, deletePosition, movePosition,
 } from '@/lib/firestore/board-positions';
 import { deleteBoardApplication } from '@/lib/firestore/boardApplications';
+import { addCampaign } from '@/lib/firestore/applicationCampaigns';
 import { onIdTokenChanged } from 'firebase/auth';
 
 const mockEvent = { id: 'evt-1', title: 'Test Event', description: 'Desc', location: 'Loc', image: '', category: 'workshop' as const, status: 'upcoming' as const, registrationRequired: false, eventStartAt: '2026-01-01T00:00:00Z' };
@@ -517,6 +518,20 @@ describe('AppContext', () => {
       const returned = await act(async () => result.current.dispatch({ firestoreAction: 'ADD_JOB', payload }));
       expect(addJob).toHaveBeenCalledWith(payload);
       expect(returned).toBe('new-job-id');
+    });
+
+    it('ADD_CAMPAIGN calls addCampaign and returns the id (so custom questions can be saved)', async () => {
+      (addCampaign as jest.Mock).mockResolvedValue('new-campaign-id');
+      const { result } = renderApp();
+      const payload = {
+        title: 'Spring 2026', subtitle: 'Sub', description: 'Desc', deadline: '2026-03-01',
+        status: 'draft' as const, teams: ['it', 'development'],
+        teamInfo: { it: { name: 'IT' } },
+        enabledStandardFields: ['name', 'email', 'motivation'],
+      };
+      const returned = await act(async () => result.current.dispatch({ firestoreAction: 'ADD_CAMPAIGN', payload }));
+      expect(addCampaign).toHaveBeenCalledWith(payload);
+      expect(returned).toBe('new-campaign-id');
     });
 
     it('UPDATE_JOB calls updateJob', async () => {

--- a/__tests__/contexts/AppContext.test.tsx
+++ b/__tests__/contexts/AppContext.test.tsx
@@ -62,6 +62,22 @@ jest.mock('@/lib/firestore/boardApplications', () => ({
   deleteBoardApplication: jest.fn(),
 }));
 
+jest.mock('@/lib/firestore/applicationCampaigns', () => ({
+  subscribeToCampaigns: jest.fn(() => mockUnsubscribe),
+  addCampaign: jest.fn(),
+  updateCampaign: jest.fn(),
+  deleteCampaign: jest.fn(),
+}));
+
+jest.mock('@/lib/firestore/campaignQuestions', () => ({
+  deleteCampaignQuestionsByCampaign: jest.fn(),
+}));
+
+jest.mock('@/lib/firestore/teamApplications', () => ({
+  subscribeToTeamApplications: jest.fn(() => mockUnsubscribe),
+  deleteTeamApplication: jest.fn(),
+}));
+
 import { AppProvider, useApp } from '@/contexts/AppContext';
 import {
   subscribeToEvents, addEvent, updateEvent, deleteEvent,

--- a/__tests__/helpers/fixtures.ts
+++ b/__tests__/helpers/fixtures.ts
@@ -6,6 +6,8 @@ export const defaultAppState = {
   jobs: [],
   boardPositions: [],
   applicants: [],
+  campaigns: [],
+  teamApplications: [],
   registrationQuestions: [],
   isLoading: false,
   error: null,

--- a/__tests__/helpers/fixtures.ts
+++ b/__tests__/helpers/fixtures.ts
@@ -7,6 +7,7 @@ export const defaultAppState = {
   boardPositions: [],
   applicants: [],
   campaigns: [],
+  campaignsLoaded: false,
   teamApplications: [],
   registrationQuestions: [],
   isLoading: false,

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -1,0 +1,8 @@
+import { handleApplicationPost } from '@/lib/apply-handler';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  return handleApplicationPost(req, 'team');
+}

--- a/app/api/apply/route.ts
+++ b/app/api/apply/route.ts
@@ -1,0 +1,8 @@
+import { handleApplicationPost } from '@/lib/apply-handler';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  return handleApplicationPost(req, 'team');
+}

--- a/app/apply/page.tsx
+++ b/app/apply/page.tsx
@@ -1,5 +1,8 @@
 import Link from 'next/link';
 import { ArrowRight, Users, Landmark } from 'lucide-react';
+import { Card } from '@/components/ui/Card';
+import { Tag, type TagVariant } from '@/components/ui/Tag';
+import { Button } from '@/components/ui/Button';
 
 const APPLY_TYPES = [
   {
@@ -25,18 +28,11 @@ const APPLY_TYPES = [
   // },
 ];
 
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    open: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
-    closed: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
-    'coming soon': 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-  };
-  return (
-    <span className={`inline-block text-xs font-semibold uppercase tracking-wider px-2.5 py-0.5 rounded-full ${styles[status] || styles.closed}`}>
-      {status}
-    </span>
-  );
-}
+const STATUS_VARIANT: Record<string, TagVariant> = {
+  open: 'green',
+  closed: 'gray',
+  'coming soon': 'yellow',
+};
 
 export default function ApplyLandingPage() {
   return (
@@ -55,10 +51,13 @@ export default function ApplyLandingPage() {
         <div className="grid gap-6">
           {APPLY_TYPES.map((type) => {
             const Icon = type.icon;
+            const isOpen = type.status === 'open';
             return (
-              <div
+              <Card
                 key={type.slug}
-                className="group relative rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 transition-all duration-200 hover:shadow-lg hover:border-red-300 dark:hover:border-red-700"
+                hover
+                padding="md"
+                className="group relative border-gray-200 dark:border-gray-700 hover:border-red-300 dark:hover:border-red-700"
               >
                 <div className="flex items-start gap-4">
                   <div className="shrink-0 w-12 h-12 rounded-lg bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
@@ -67,18 +66,19 @@ export default function ApplyLandingPage() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-3 mb-1">
                       <h2 className="text-xl font-bold text-gray-900 dark:text-white">{type.title}</h2>
-                      <StatusBadge status={type.status} />
+                      <Tag variant={STATUS_VARIANT[type.status] || 'gray'} size="sm">
+                        {type.status}
+                      </Tag>
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-400">{type.description}</p>
                   </div>
                   <div className="shrink-0 pt-1">
-                    {type.status === 'open' ? (
-                      <Link
-                        href={`/apply/${type.slug}`}
-                        className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
-                      >
-                        Apply now <ArrowRight className="h-4 w-4" />
-                      </Link>
+                    {isOpen ? (
+                      <Button asChild size="sm" className="bg-red-600 hover:bg-red-700 text-white">
+                        <Link href={`/apply/${type.slug}`}>
+                          Apply now <ArrowRight className="h-4 w-4" />
+                        </Link>
+                      </Button>
                     ) : (
                       <span className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 text-sm font-medium cursor-not-allowed">
                         Unavailable
@@ -86,7 +86,7 @@ export default function ApplyLandingPage() {
                     )}
                   </div>
                 </div>
-              </div>
+              </Card>
             );
           })}
         </div>

--- a/app/apply/page.tsx
+++ b/app/apply/page.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link';
+import { ArrowRight, Users, Landmark } from 'lucide-react';
+
+const APPLY_TYPES = [
+  {
+    slug: 'team',
+    title: 'Join a Team',
+    description: 'Apply to join one of our active teams — Development, IT, Growth, Partnerships & Events, or Research.',
+    icon: Users,
+    status: 'open' as const,
+  },
+  {
+    slug: 'board',
+    title: 'Board Positions',
+    description: 'Run for the board of UU AI Society. Nominations open during the annual election period.',
+    icon: Landmark,
+    status: 'closed' as const,
+  },
+  // {
+  //   slug: 'research',
+  //   title: 'Research Groups',
+  //   description: 'Join a research group working on AI projects. Open to all members.',
+  //   icon: BookOpen,
+  //   status: 'coming soon' as const,
+  // },
+];
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    open: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    closed: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
+    'coming soon': 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  };
+  return (
+    <span className={`inline-block text-xs font-semibold uppercase tracking-wider px-2.5 py-0.5 rounded-full ${styles[status] || styles.closed}`}>
+      {status}
+    </span>
+  );
+}
+
+export default function ApplyLandingPage() {
+  return (
+    <main className="min-h-screen bg-white dark:bg-gray-900 transition-colors">
+      <section className="relative bg-gradient-to-br from-red-600 via-red-700 to-red-800 dark:from-red-700 dark:via-red-800 dark:to-red-900 text-white">
+        <div className="absolute inset-0 bg-black/20 dark:bg-black/40" />
+        <div className="relative max-w-4xl mx-auto px-6 py-20 text-center">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Apply</h1>
+          <p className="text-lg text-red-100 max-w-2xl mx-auto">
+            Choose how you want to contribute to UU AI Society.
+          </p>
+        </div>
+      </section>
+
+      <section className="max-w-4xl mx-auto px-6 py-16">
+        <div className="grid gap-6">
+          {APPLY_TYPES.map((type) => {
+            const Icon = type.icon;
+            return (
+              <div
+                key={type.slug}
+                className="group relative rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 transition-all duration-200 hover:shadow-lg hover:border-red-300 dark:hover:border-red-700"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="shrink-0 w-12 h-12 rounded-lg bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+                    <Icon className="h-6 w-6 text-red-600 dark:text-red-400" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-1">
+                      <h2 className="text-xl font-bold text-gray-900 dark:text-white">{type.title}</h2>
+                      <StatusBadge status={type.status} />
+                    </div>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">{type.description}</p>
+                  </div>
+                  <div className="shrink-0 pt-1">
+                    {type.status === 'open' ? (
+                      <Link
+                        href={`/apply/${type.slug}`}
+                        className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
+                      >
+                        Apply now <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    ) : (
+                      <span className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 text-sm font-medium cursor-not-allowed">
+                        Unavailable
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/apply/team/page.tsx
+++ b/app/apply/team/page.tsx
@@ -1,17 +1,43 @@
-"use client"
+import type { Metadata } from "next";
+import dynamic from "next/dynamic";
 
-import { useEffect } from 'react';
-import TeamApplicationPage from '@/components/pages/TeamApplicationPage';
-import { ErrorBoundaryWrapper } from '@/components/ui/ErrorBoundaryWrapper';
-import { updatePageMeta } from '@/utils/seo';
+export const metadata: Metadata = {
+  title: "Join Our Teams",
+  description: "Apply to join UU AI Society teams",
+};
+
+const TeamApplicationPage = dynamic(
+  () => import("@/components/pages/TeamApplicationPage"),
+  {
+    loading: () => <TeamApplicationSkeleton />,
+  }
+);
 
 export default function Page() {
-  useEffect(() => {
-    updatePageMeta('Join Our Teams', 'Apply to join UU AI Society teams');
-  }, []);
+  return <TeamApplicationPage />;
+}
+
+function TeamApplicationSkeleton() {
   return (
-    <ErrorBoundaryWrapper>
-      <TeamApplicationPage />
-    </ErrorBoundaryWrapper>
+    <div className="min-h-screen bg-white dark:bg-gray-900 transition-colors duration-300">
+      <div className="bg-gradient-to-br from-red-600 via-red-700 to-red-800 dark:from-red-700 dark:via-red-800 dark:to-red-900 text-white min-h-[50vh] animate-pulse">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-16">
+          <div className="h-4 w-32 bg-red-300/50 rounded mb-6" />
+          <div className="h-12 w-full max-w-sm bg-red-300/30 rounded mb-6" />
+          <div className="h-6 w-full max-w-lg bg-red-300/20 rounded mb-6" />
+          <div className="h-5 w-48 bg-red-300/20 rounded" />
+        </div>
+      </div>
+      <div className="bg-gray-50 dark:bg-gray-900 min-h-screen py-12">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="h-8 w-48 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-6" />
+          <div className="space-y-4">
+            <div className="h-32 bg-white dark:bg-gray-800 rounded-xl animate-pulse border border-gray-200 dark:border-gray-700" />
+            <div className="h-32 bg-white dark:bg-gray-800 rounded-xl animate-pulse border border-gray-200 dark:border-gray-700" />
+            <div className="h-32 bg-white dark:bg-gray-800 rounded-xl animate-pulse border border-gray-200 dark:border-gray-700" />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/app/apply/team/page.tsx
+++ b/app/apply/team/page.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect } from 'react';
+import TeamApplicationPage from '@/components/pages/TeamApplicationPage';
+import { ErrorBoundaryWrapper } from '@/components/ui/ErrorBoundaryWrapper';
+import { updatePageMeta } from '@/utils/seo';
+
+export default function Page() {
+  useEffect(() => {
+    updatePageMeta('Join Our Teams', 'Apply to join UU AI Society teams');
+  }, []);
+  return (
+    <ErrorBoundaryWrapper>
+      <TeamApplicationPage />
+    </ErrorBoundaryWrapper>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,7 +15,9 @@ export default function LoginPage() {
   const after = () => {
     const params = new URLSearchParams(window.location.search)
     const redirect = params.get('redirect')
-    router.push(redirect || '/account')
+    // Only allow local paths to prevent open redirects to external sites
+    // (including protocol-relative URLs like //evil.com)
+    router.push(redirect && redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/account')
   }
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -13,7 +13,9 @@ export default function LoginPage() {
   }, []);
 
   const after = () => {
-    router.push('/account')
+    const params = new URLSearchParams(window.location.search)
+    const redirect = params.get('redirect')
+    router.push(redirect || '/account')
   }
 
   return (

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -3,7 +3,6 @@ import type { Metadata, Viewport } from "next";
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
   themeColor: '#c8102e',
 }
 

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -65,12 +65,14 @@ export const Footer: React.FC = () => {
             <div className="flex space-x-4">
               <a
                 href="https://linkedin.com/company/uu-ai-society"
+                aria-label="LinkedIn"
                 className="text-gray-400 hover:text-white transition-colors"
               >
                 <HugeiconsIcon icon={LinkedinIcon} className="h-5 w-5" />
               </a>
               <a
                 href="https://instagram.com/uuaisociety"
+                aria-label="Instagram"
                 className="text-gray-400 hover:text-white transition-colors"
               >
                 <HugeiconsIcon icon={InstagramIcon} className="h-5 w-5" />
@@ -80,7 +82,7 @@ export const Footer: React.FC = () => {
 
           {/* Quick Links */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Quick Links</h3>
+            <h2 className="text-lg font-semibold mb-4">Quick Links</h2>
             <ul className="space-y-2">
               <li><Link href="/" className="text-gray-300 hover:text-white transition-colors">Home</Link></li>
               <li><Link href="/events" className="text-gray-300 hover:text-white transition-colors">Events</Link></li>
@@ -93,7 +95,7 @@ export const Footer: React.FC = () => {
 
           {/* Contact Info */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Contact</h3>
+            <h2 className="text-lg font-semibold mb-4">Contact</h2>
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
                 <Mail className="h-4 w-4 text-gray-400" />
@@ -157,9 +159,9 @@ export const Footer: React.FC = () => {
 
         {/* Partners strip */}
         <div className="py-8 border-t border-gray-900">
-          <h3 className="text-center text-lg font-semibold mb-6 text-gray-100">
+          <h2 className="text-center text-lg font-semibold mb-6 text-gray-100">
             Our partners
-          </h3>
+          </h2>
           <div className="grid grid-cols-2 [@media(max-width:350px)]:grid-cols-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6  gap-6 items-center">
             {/* Fill out grid */}
             {Array.from({ length: 0 }).map((_, idx) => (

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -25,7 +25,7 @@ export const Header: React.FC = () => {
 
   // Hide the Apply CTA when no open application campaign exists (show it while
   // campaigns are still loading to avoid a flicker on first paint).
-  const showApply = !state.campaignsLoaded || state.campaigns.some((c) => c.status === "open");
+  const showApply = isAdmin; //!state.campaignsLoaded || state.campaigns.some((c) => c.status === "open");
 
   const isHomePage = pathname === '/';
   const isTransparent = isHomePage && !isScrolled;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -163,6 +163,7 @@ export const Header: React.FC = () => {
   const navigation = [
     { name: 'Home', href: '/' },
     { name: 'Events', href: '/events' },
+    { name: 'Apply', href: '/apply/team' },
     { name: 'Job board', href: '/careers' },
     { name: 'About', href: '/about' },
     { name: 'Contact', href: '/contact' }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,13 +3,15 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, ArrowRight } from 'lucide-react';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { useAdmin } from '@/hooks/useAdmin';
+import { useApp } from '@/contexts/AppContext';
 import { useEffect, useState, useRef } from 'react';
 import { getUserProfile, type UserProfile } from '@/lib/firestore/users';
 
 export const Header: React.FC = () => {
+  const { state } = useApp();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isProjectsOpen, setIsProjectsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
@@ -20,6 +22,10 @@ export const Header: React.FC = () => {
   const pathname = usePathname();
   const { user, isAdmin, loading, logout } = useAdmin();
   const [profile, setProfile] = useState<UserProfile | null>(null);
+
+  // Hide the Apply CTA when no open application campaign exists (show it while
+  // campaigns are still loading to avoid a flicker on first paint).
+  const showApply = !state.campaignsLoaded || state.campaigns.some((c) => c.status === "open");
 
   const isHomePage = pathname === '/';
   const isTransparent = isHomePage && !isScrolled;
@@ -127,23 +133,6 @@ export const Header: React.FC = () => {
   }, [isMenuOpen]);
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!isMenuOpen) return;
-      const target = event.target as Node;
-      const isButton = mobileButtonRef.current?.contains(target) ?? false;
-      const isMenu = mobileMenuRef.current?.contains(target) ?? false;
-      if (!isButton && !isMenu) {
-        setIsMenuOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isMenuOpen]);
-
-  useEffect(() => {
     let ticking = false;
     const handleScroll = () => {
       if (!ticking) {
@@ -163,7 +152,6 @@ export const Header: React.FC = () => {
   const navigation = [
     { name: 'Home', href: '/' },
     { name: 'Events', href: '/events' },
-    { name: 'Apply', href: '/apply/team' },
     { name: 'Job board', href: '/careers' },
     { name: 'About', href: '/about' },
     { name: 'Contact', href: '/contact' }
@@ -191,7 +179,7 @@ export const Header: React.FC = () => {
                 <>
                   <span className="truncate max-w-[200px]">{profile?.displayName || profile?.name || user.displayName || (user as unknown as { name?: string }).name || user.email}</span>
                   <Link href="/account" className={`${isTransparent ? 'text-white/90 hover:text-white' : 'text-gray-700 dark:text-gray-300'}`}>Account</Link>
-                  <a onClick={() => logout()} className={`${isTransparent ? 'text-white/90 hover:text-white' : 'text-gray-700 dark:text-gray-300'} no-underline hover:underline cursor-pointer`}>Logout</a>
+                  <button onClick={() => logout()} className={`${isTransparent ? 'text-white/90 hover:text-white' : 'text-gray-700 dark:text-gray-300'} hover:underline bg-transparent border-none p-0 cursor-pointer text-sm`}>Logout</button>
                 </>
               )}
             </div>
@@ -235,6 +223,8 @@ export const Header: React.FC = () => {
                      <div key="Projects" className="relative" ref={projectsRef}>
                        <button
                           onClick={() => setIsProjectsOpen(!isProjectsOpen)}
+                          aria-expanded={isProjectsOpen}
+                          aria-haspopup="true"
                           className={`px-2 lg:px-3 py-2 rounded-md text-xs lg:text-sm font-medium whitespace-nowrap transition-colors duration-200 flex items-center gap-1 cursor-pointer ${getNavClass(isActive('/projects'))}`}
                        >
                          Projects
@@ -296,16 +286,30 @@ export const Header: React.FC = () => {
                   )}
                     {/* Theme toggle */}
                      <ThemeToggle isHomePage={isTransparent} />
+                     {showApply && (
+                       <Link
+                         href="/apply/team"
+                         className={`group inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs border border-white/10 hover:border-white/0 lg:text-sm font-semibold whitespace-nowrap transition-colors duration-200 shadow-sm ${
+                           isTransparent
+                             ? 'bg-white/20 text-white hover:bg-white/30 backdrop-blur-sm'
+                             : 'bg-red-600 dark:bg-red-700 text-white hover:bg-red-700'
+                         }`}
+                       >
+                         Apply
+                         <ArrowRight className={`h-3.5 w-3.5 transition-transform duration-200 ${isTransparent ? 'group-hover:translate-x-0.5' : ''}`} />
+                       </Link>
+                     )}
                  </nav>
               </div>
 
                {/* Mobile menu button */}
                <div className="md:hidden">
-                <button
+                 <button
                     ref={mobileButtonRef}
                     onClick={() => setIsMenuOpen(!isMenuOpen)}
                     className={`p-2 rounded-md transition-all hover:scale-110 ${getMobileButtonClass()}`}
-                    aria-expanded="false"
+                    aria-expanded={isMenuOpen}
+                    aria-controls="mobile-menu"
                   >
                    <span className="sr-only">Open main menu</span>
                    {isMenuOpen ? (
@@ -320,6 +324,7 @@ export const Header: React.FC = () => {
                 {/* Mobile Navigation */}
                 <div
                   ref={mobileMenuRef}
+                  id="mobile-menu"
                   className={`md:hidden absolute top-full left-0 right-0 z-50 transition-all duration-300 overflow-hidden ${
                     isMenuOpen 
                       ? 'opacity-100 translate-y-0' 
@@ -338,10 +343,25 @@ export const Header: React.FC = () => {
                       {item.name}
                     </Link>
                   ))}
+                    {showApply && (
+                      <Link
+                        href="/apply/team"
+                        onClick={() => setIsMenuOpen(false)}
+                        className={`block px-3 py-2 rounded-lg text-sm font-semibold text-center transition-colors duration-200 ${
+                          isTransparent
+                            ? 'bg-white/20 text-white hover:bg-white/30 backdrop-blur-sm'
+                            : 'bg-red-600 text-white hover:bg-red-700'
+                        }`}
+                      >
+                        Apply
+                      </Link>
+                    )}
                     {isAdmin && (
                      <div key="Projects" className="relative" ref={mobileProjectsRef}>
                        <button
                          onClick={(e) => { e.stopPropagation(); setIsProjectsOpen(!isProjectsOpen); }}
+                         aria-expanded={isProjectsOpen}
+                         aria-haspopup="true"
                          className={`px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center gap-1 cursor-pointer ${getNavClass(isActive('/projects'))}`}
                        >
                          Projects

--- a/components/pages/JoinPage.tsx
+++ b/components/pages/JoinPage.tsx
@@ -129,10 +129,10 @@ const JoinPage: React.FC = () => {
               <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Personal Information</h3>
               <div className="grid md:grid-cols-2 gap-4">
                 <FieldGroup label="Display name" requiredHint="Required. Shown publicly.">
-                  <InputBase placeholder="e.g. Alex" value={form.displayName || ''} onChange={(e) => setForm(f => ({ ...f, displayName: e.target.value }))} />
+                  <InputBase maxLength={100} placeholder="e.g. Alex" value={form.displayName || ''} onChange={(e) => setForm(f => ({ ...f, displayName: e.target.value }))} />
                 </FieldGroup>
-                <FieldGroup label="Full name" requiredHint="Required. Your legal name or preferred full name.">
-                  <InputBase placeholder="e.g. Alex Doe" value={form.name || ''} onChange={(e) => setForm(f => ({ ...f, name: e.target.value }))} />
+                <FieldGroup label="Full name" requiredHint="Required">
+                  <InputBase maxLength={100} placeholder="e.g. Alex Doe" value={form.name || ''} onChange={(e) => setForm(f => ({ ...f, name: e.target.value }))} />
                 </FieldGroup>
               </div>
 
@@ -153,13 +153,13 @@ const JoinPage: React.FC = () => {
                   </SelectBase>
                 </FieldGroup>
                 <FieldGroup label="LinkedIn URL" requiredHint="Optional">
-                  <InputBase placeholder="https://linkedin.com/in/..." value={form.linkedin || ''} onChange={(e) => setForm(f => ({ ...f, linkedin: e.target.value }))} />
+                  <InputBase maxLength={200} placeholder="https://linkedin.com/in/..." value={form.linkedin || ''} onChange={(e) => setForm(f => ({ ...f, linkedin: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="GitHub URL" requiredHint="Optional">
-                  <InputBase placeholder="https://github.com/username" value={form.github || ''} onChange={(e) => setForm(f => ({ ...f, github: e.target.value }))} />
+                  <InputBase maxLength={200} placeholder="https://github.com/username" value={form.github || ''} onChange={(e) => setForm(f => ({ ...f, github: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="Website" requiredHint="Optional">
-                  <InputBase placeholder="https://example.com" value={form.website || ''} onChange={(e) => setForm(f => ({ ...f, website: e.target.value }))} />
+                  <InputBase maxLength={500} placeholder="https://example.com" value={form.website || ''} onChange={(e) => setForm(f => ({ ...f, website: e.target.value }))} />
                 </FieldGroup>
               </div>
 
@@ -173,10 +173,10 @@ const JoinPage: React.FC = () => {
                   </SelectBase>
                 </FieldGroup>
                 <FieldGroup label="Program / Major" requiredHint="Required if student.">
-                  <InputBase placeholder="e.g. Computer Science" value={form.program || ''} onChange={(e) => setForm(f => ({ ...f, program: e.target.value }))} />
+                  <InputBase maxLength={200} placeholder="e.g. Computer Science" value={form.program || ''} onChange={(e) => setForm(f => ({ ...f, program: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="Expected Graduation Year" requiredHint="Optional">
-                  <InputBase placeholder="e.g. 2026" type="number" value={form.expectedGraduationYear ?? ''} onChange={(e) => setForm(f => ({ ...f, expectedGraduationYear: e.target.value ? Number(e.target.value) : undefined }))} />
+                  <InputBase placeholder="e.g. 2026" type="number" min={1900} max={2100} value={form.expectedGraduationYear ?? ''} onChange={(e) => setForm(f => ({ ...f, expectedGraduationYear: e.target.value ? Number(e.target.value) : undefined }))} />
                 </FieldGroup>
                 <FieldGroup label="Gender" requiredHint="Optional">
                   <SelectBase value={form.gender || 'other'} onChange={(e) => setForm(f => ({ ...f, gender: e.target.value }))}>
@@ -214,12 +214,12 @@ const JoinPage: React.FC = () => {
                 </FieldGroup>
                 {(form.heardOfUs === '' || (form.heardOfUs && !['posters','instagram','linkedin','friends','events','lecture'].includes(form.heardOfUs))) && (
                   <FieldGroup label="If other, please specify" requiredHint="Optional">
-                    <InputBase placeholder="Type here" value={form.heardOfUs || ''} onChange={(e)=>setForm(f=>({...f, heardOfUs: e.target.value}))} />
+                    <InputBase maxLength={200} placeholder="Type here" value={form.heardOfUs || ''} onChange={(e)=>setForm(f=>({...f, heardOfUs: e.target.value}))} />
                   </FieldGroup>
                 )}
               </div>
               <FieldGroup label="Bio" requiredHint="Optional">
-                <TextareaBase placeholder="Write a short bio" value={form.bio || ''} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value }))} />
+                <TextareaBase maxLength={500} placeholder="Write a short bio" value={form.bio || ''} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value }))} />
               </FieldGroup>
               <div className="flex items-center gap-6">
                 <label className="flex items-center gap-2 text-gray-800 dark:text-gray-200">

--- a/components/pages/TeamApplicationPage.tsx
+++ b/components/pages/TeamApplicationPage.tsx
@@ -8,14 +8,14 @@ import {
   GraduationCap, Briefcase, Tag, Lock, Loader2,
 } from "lucide-react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { FieldGroup, InputBase, SelectBase, TextareaBase } from "@/components/ui/Form";
-import FloatingSymbolsCanvas from "@/components/FloatingSymbolsCanvas";
 import MultiStepWizard, { WizardStep } from "@/components/ui/MultiStepWizard";
 import TeamRanker, { type TeamRankEntry } from "@/components/ui/TeamRanker";
-import { LinkedInUrlInput } from "@/components/ui/LinkedInUrlInput";
+import { LinkedInUrlInput, LINKEDIN_PREFIX } from "@/components/ui/LinkedInUrlInput";
 import TagComponent from "@/components/ui/Tag";
 import PDFDropzone from "@/components/ui/PDFDropzone";
 import { useApp } from "@/contexts/AppContext";
@@ -30,6 +30,11 @@ import {
   AREAS_OF_INTEREST,
   MOTIVATION_MAX_CHARS,
 } from "./apply/sampleData";
+
+const FloatingSymbolsCanvas = dynamic(
+  () => import("@/components/FloatingSymbolsCanvas"),
+  { ssr: false }
+);
 
 const TEAM_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   it: Server,
@@ -58,6 +63,11 @@ const TEAM_NAMES: Record<string, string> = {
 };
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const DEFAULT_STANDARD_FIELDS = [
+  "name", "email", "gender", "university", "program", "graduationYear",
+  "linkedin", "resume", "interests", "teamRanking", "weeklyHours", "motivation",
+];
 
 interface TeamFormData {
   name: string;
@@ -95,7 +105,28 @@ export default function TeamApplicationPage() {
   // Find the first open campaign
   const campaign: ApplicationCampaign | null = state.campaigns.find((c) => c.status === "open") || null;
 
+  // Which standard fields this campaign actually wants shown/required
+  const enabledFields = campaign?.enabledStandardFields?.length
+    ? campaign.enabledStandardFields
+    : DEFAULT_STANDARD_FIELDS;
+  const fieldEnabled = (id: string) => enabledFields.includes(id);
+
   const [step, setStep] = useState(0);
+
+  // Campaign deadline passed — lock the form
+  const [deadlinePassed, setDeadlinePassed] = useState(false);
+  useEffect(() => {
+    if (!campaign?.deadline) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDeadlinePassed(false);
+      return;
+    }
+    const ms = Date.parse(campaign.deadline);
+    // eslint-disable-next-line react-hooks/purity -- reading the clock inside an effect is intentional
+    const passed = !Number.isNaN(ms) && ms <= Date.now();
+    setDeadlinePassed(passed);
+  }, [campaign]);
+  const isPastDeadline = deadlinePassed;
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [form, setForm] = useState<TeamFormData>(emptyForm);
@@ -104,6 +135,8 @@ export default function TeamApplicationPage() {
   const [customQuestions, setCustomQuestions] = useState<CampaignQuestion[]>([]);
 
   // Check if the current user has already applied to this campaign
+  // Best-effort: only reliable for admins (state is populated) or when the
+  // direct query succeeds; the server 409 is the authoritative enforcement.
   const [hasApplied, setHasApplied] = useState(false);
   useEffect(() => {
     if (!campaign?.id || !form.email) {
@@ -111,20 +144,21 @@ export default function TeamApplicationPage() {
       setHasApplied(false);
       return;
     }
-    let cancelled = false;
     const emailNorm = form.email.trim().toLowerCase();
-    // First check from reactive state if available (fast path)
+    // First check from reactive state if available (fast path, admin only)
     if (state.teamApplications.some(
       (a) => a.emailNormalized === emailNorm && a.campaignId === campaign.id
     )) {
       setHasApplied(true);
       return;
     }
-    // Fallback: direct Firestore query for non-admin users
-    getTeamApplicationByEmail(emailNorm, campaign.id).then((app) => {
-      if (!cancelled) setHasApplied(!!app);
-    });
-    return () => { cancelled = true; };
+    // Debounce so typing an email doesn't swap the page mid-entry
+    const t = setTimeout(() => {
+      getTeamApplicationByEmail(emailNorm, campaign.id)
+        .then((app) => setHasApplied(!!app))
+        .catch(() => setHasApplied(false));
+    }, 600);
+    return () => clearTimeout(t);
   }, [campaign?.id, form.email, state.teamApplications]);
 
 
@@ -213,6 +247,10 @@ export default function TeamApplicationPage() {
   const handleSubmit = async () => {
     if (!form.agree) return;
     if (!campaign) return;
+    if (hasApplied) {
+      notify({ type: "error", title: "Already applied", message: "You have already submitted an application for this campaign." });
+      return;
+    }
     if (!auth.currentUser) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { resume: _resume, ...rest } = form;
@@ -226,26 +264,29 @@ export default function TeamApplicationPage() {
       fd.append("campaignId", campaign.id);
       fd.append("name", form.name);
       fd.append("email", form.email);
-      fd.append("gender", form.gender);
-      fd.append("university", form.university);
-      fd.append("program", form.program);
-      fd.append("graduationYear", form.expectedGraduationYear);
-      fd.append("linkedin", form.linkedin);
-      fd.append("customTeam", form.customTeam);
-      fd.append("weeklyHours", String(form.weeklyHours));
-      fd.append("motivation", form.motivation);
+      if (fieldEnabled("gender")) fd.append("gender", form.gender);
+      if (fieldEnabled("university")) fd.append("university", form.university);
+      if (fieldEnabled("program")) fd.append("program", form.program);
+      if (fieldEnabled("graduationYear")) fd.append("graduationYear", form.expectedGraduationYear);
+      if (fieldEnabled("linkedin")) fd.append("linkedin", form.linkedin);
+      if (fieldEnabled("teamRanking")) fd.append("customTeam", form.customTeam);
+      if (fieldEnabled("weeklyHours")) fd.append("weeklyHours", String(form.weeklyHours));
+      if (fieldEnabled("motivation")) fd.append("motivation", form.motivation);
       fd.append("agree", String(form.agree));
       fd.append("newsletter", String(form.newsletter));
-      fd.append("interests", JSON.stringify(form.interests));
-      fd.append("customInterest", form.customInterest);
-      fd.append("teamRanking", JSON.stringify(form.teamRanking.map((t) => t.id)));
+      if (fieldEnabled("interests")) {
+        fd.append("interests", JSON.stringify(form.interests));
+        fd.append("customInterest", form.customInterest);
+      }
+      if (fieldEnabled("teamRanking")) fd.append("teamRanking", JSON.stringify(form.teamRanking.map((t) => t.id)));
       fd.append("customAnswers", JSON.stringify(form.customAnswers));
-      if (form.resume) fd.append("resume", form.resume, form.resume.name);
+      if (fieldEnabled("resume") && form.resume) fd.append("resume", form.resume, form.resume.name);
 
       const res = await fetch("/api/applications", { method: "POST", body: fd });
       const json = await res.json();
       if (!res.ok) {
         notify({ type: "error", title: "Submission failed", message: json?.error || "Unknown error" });
+        if (json?.code === "DUPLICATE_CAMPAIGN") setHasApplied(true);
         return;
       }
       setSubmitted(true);
@@ -258,8 +299,8 @@ export default function TeamApplicationPage() {
     }
   };
 
-  // No open campaigns
-  if (state.campaigns.length > 0 && !campaign) {
+  // No open campaigns (loaded, but none are currently open)
+  if (state.campaignsLoaded && !campaign) {
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 pt-24 pb-12 transition-colors duration-300 flex items-center">
         <div className="max-w-md mx-auto px-4 text-center">
@@ -329,17 +370,43 @@ export default function TeamApplicationPage() {
     );
   }
 
-  // If not signed in, show login prompt (the form requires auth to POST)
-  if (!authLoading && !profile && !form.email) {
-    // Continue rendering — they can fill it but submission will require sign-in
-    // We'll show a small note reminding them to sign in
+  // Campaign deadline has passed
+  if (isPastDeadline) {
+    return (
+      <div className="min-h-screen bg-white dark:bg-gray-900 pt-24 pb-12 transition-colors duration-300 flex items-center">
+        <div className="max-w-md mx-auto px-4 text-center">
+          <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-950/30 flex items-center justify-center mx-auto mb-6">
+            <Clock className="h-8 w-8 text-red-600 dark:text-red-400" />
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-3">Applications Closed</h1>
+          <p className="text-gray-600 dark:text-gray-300 mb-6">
+            The application deadline for{" "}
+            <strong className="text-red-600 dark:text-red-400">{campaign.title}</strong>&nbsp;has passed
+            ({campaign.deadline}). We&apos;re no longer accepting submissions.
+          </p>
+          <Link href="/">
+            <Button variant="outline">Back to home</Button>
+          </Link>
+        </div>
+      </div>
+    );
   }
+
+  // If not signed in, the form still renders but submission will require
+  // sign-in (redirect handled in handleSubmit).
+  const requiredCustomAnswered = customQuestions
+    .filter((q) => q.required)
+    .every((q) => {
+      const ans = form.customAnswers[q.id];
+      if (Array.isArray(ans)) return ans.length > 0;
+      return typeof ans === "string" && ans.trim().length > 0;
+    });
 
   const canNext =
     step === 0 ? true :
     step === 1 ? !!form.name.trim() && EMAIL_RE.test(form.email.trim()) :
-    step === 2 ? !!form.linkedin.trim() && form.linkedin !== "https://" && (form.interests.length > 0 || !!form.customInterest.trim()) :
-    step === 3 ? form.motivation.trim().length >= 25 && form.teamRanking.length >= 1 :
+    step === 2 ? (!fieldEnabled("linkedin") || form.linkedin.trim().length > LINKEDIN_PREFIX.length) && (!fieldEnabled("interests") || form.interests.length > 0 || !!form.customInterest.trim()) && requiredCustomAnswered :
+    step === 3 ? (!fieldEnabled("motivation") || form.motivation.trim().length >= 25) && (!fieldEnabled("teamRanking") || form.teamRanking.length >= 1) :
     true;
 
   return (
@@ -379,7 +446,7 @@ export default function TeamApplicationPage() {
       )}
 
       {/* Wizard */}
-      <div ref={wizardRef} className="scroll-mt-24 py-12 bg-gray-50 dark:bg-gray-900 min-h-screen">
+      <div id="wizard" ref={wizardRef} className="scroll-mt-24 py-12 bg-gray-50 dark:bg-gray-900 min-h-screen">
         <MultiStepWizard
           steps={WIZARD_STEPS}
           currentStep={step}
@@ -462,46 +529,56 @@ export default function TeamApplicationPage() {
                       <InputBase type="email" maxLength={254} value={form.email} onChange={(e) => set("email", e.target.value)} />
                     </FieldGroup>
                   </div>
-                  <FieldGroup label="Gender" requiredHint="Optional.">
-                    <SelectBase value={form.gender} onChange={(e) => set("gender", e.target.value)}>
-                      <option value="">Prefer not to say</option>
-                      <option value="male">Male</option>
-                      <option value="female">Female</option>
-                      <option value="nonbinary">Non-binary</option>
-                      <option value="other">Other</option>
-                    </SelectBase>
-                  </FieldGroup>
-                  <div className="grid md:grid-cols-2 gap-4">
-                    <FieldGroup label="University" requiredHint="Required if student.">
-                      <SelectBase value={form.university} onChange={(e) => set("university", e.target.value)}>
-                        <option value="Uppsala">Uppsala University</option>
-                        <option value="none">None</option>
+                  {fieldEnabled("gender") && (
+                    <FieldGroup label="Gender" requiredHint="Optional.">
+                      <SelectBase value={form.gender} onChange={(e) => set("gender", e.target.value)}>
+                        <option value="">Prefer not to say</option>
+                        <option value="male">Male</option>
+                        <option value="female">Female</option>
+                        <option value="nonbinary">Non-binary</option>
                         <option value="other">Other</option>
                       </SelectBase>
                     </FieldGroup>
-                    <FieldGroup label="Programme" requiredHint="Required if student.">
-                      <SelectBase value={form.program} onChange={(e) => set("program", e.target.value)}>
-                        <option value="">Select a programme</option>
-                        {UU_PROGRAMMES.map((prog) => (
-                          <option key={prog} value={prog}>{prog}</option>
-                        ))}
-                      </SelectBase>
+                  )}
+                  {(fieldEnabled("university") || fieldEnabled("program")) && (
+                    <div className="grid md:grid-cols-2 gap-4">
+                      {fieldEnabled("university") && (
+                        <FieldGroup label="University" requiredHint="Required if student.">
+                          <SelectBase value={form.university} onChange={(e) => set("university", e.target.value)}>
+                            <option value="Uppsala">Uppsala University</option>
+                            <option value="none">None</option>
+                            <option value="other">Other</option>
+                          </SelectBase>
+                        </FieldGroup>
+                      )}
+                      {fieldEnabled("program") && (
+                        <FieldGroup label="Programme" requiredHint="Required if student.">
+                          <SelectBase value={form.program} onChange={(e) => set("program", e.target.value)}>
+                            <option value="">Select a programme</option>
+                            {UU_PROGRAMMES.map((prog) => (
+                              <option key={prog} value={prog}>{prog}</option>
+                            ))}
+                          </SelectBase>
+                        </FieldGroup>
+                      )}
+                    </div>
+                  )}
+                  {fieldEnabled("graduationYear") && (
+                    <FieldGroup label="Expected graduation year" requiredHint="Optional">
+                      <InputBase
+                        type="number"
+                        min={1900}
+                        max={2100}
+                        maxLength={4}
+                        placeholder="e.g. 2027"
+                        value={form.expectedGraduationYear}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          if (v.length <= 4) set("expectedGraduationYear", v);
+                        }}
+                      />
                     </FieldGroup>
-                  </div>
-                  <FieldGroup label="Expected graduation year" requiredHint="Optional">
-                    <InputBase
-                      type="number"
-                      min={1900}
-                      max={2100}
-                      maxLength={4}
-                      placeholder="e.g. 2027"
-                      value={form.expectedGraduationYear}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        if (v.length <= 4) set("expectedGraduationYear", v);
-                      }}
-                    />
-                  </FieldGroup>
+                  )}
                 </div>
               </Card>
             </div>
@@ -518,20 +595,25 @@ export default function TeamApplicationPage() {
               </div>
               <Card>
                 <div className="p-6 space-y-5">
-                  <FieldGroup label="LinkedIn URL" requiredHint="Required.">
-                    <LinkedInUrlInput value={form.linkedin} onChange={(v) => set("linkedin", v)} />
-                  </FieldGroup>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Resume / CV (PDF, max 3MB) <span className="text-[11px] font-normal text-gray-500">Optional.</span>
-                    </label>
-                    <PDFDropzone
-                      file={form.resume}
-                      onChange={(f) => set("resume", f)}
-                      onError={(msg) => notify({ type: "error", title: "Resume upload", message: msg })}
-                    />
-                  </div>
-                  <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+                  {fieldEnabled("linkedin") && (
+                    <FieldGroup label="LinkedIn URL" requiredHint="Required.">
+                      <LinkedInUrlInput value={form.linkedin} onChange={(v) => set("linkedin", v)} />
+                    </FieldGroup>
+                  )}
+                  {fieldEnabled("resume") && (
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+                        Resume / CV (PDF, max 3MB) <span className="text-[11px] font-normal text-gray-500">Optional.</span>
+                      </label>
+                      <PDFDropzone
+                        file={form.resume}
+                        onChange={(f) => set("resume", f)}
+                        onError={(msg) => notify({ type: "error", title: "Resume upload", message: msg })}
+                      />
+                    </div>
+                  )}
+                  {fieldEnabled("interests") && (
+                    <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
                     <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-1 mt-4">
                       Areas of Interest
                     </h3>
@@ -590,6 +672,7 @@ export default function TeamApplicationPage() {
                       {form.interests.length} area{form.interests.length !== 1 ? "s" : ""} selected
                     </p>
                   </div>
+                  )}
 
                   {/* Custom questions */}
                   {customQuestions.length > 0 && (
@@ -685,70 +768,76 @@ export default function TeamApplicationPage() {
               </div>
               <Card>
                 <div className="p-6 space-y-6">
-                  <TeamRanker
-                    ranking={form.teamRanking}
-                    onChange={(ranking) => set("teamRanking", ranking)}
-                    availableTeamIds={campaign.teams}
-                    teamName={(id) => (campaign.teamInfo?.[id]?.name || TEAM_NAMES[id] || id)}
-                    iconMap={TEAM_ICONS}
-                    customTeam={form.customTeam}
-                    onCustomTeamChange={(val) => set("customTeam", val)}
-                  />
-                  <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-4">
-                      Weekly Availability
-                    </h3>
-                    <div className="flex items-start gap-4">
-                      <div className="flex-1 min-w-0">
-                        <input
-                          type="range"
-                          min={0}
-                          max={12}
-                          step={1}
-                          value={form.weeklyHours}
-                          onChange={(e) => set("weeklyHours", Number(e.target.value))}
-                          className="w-full accent-red-600 dark:accent-red-500"
-                        />
-                        {/* Labels aligned under the slider (this column only) */}
-                        <div className="flex justify-between text-xs text-gray-400 dark:text-gray-500 mt-1">
-                          <span>Casual</span>
-                          <span>Few hrs</span>
-                          <span>Committed</span>
-                          <span>Very active</span>
+                  {fieldEnabled("teamRanking") && (
+                    <TeamRanker
+                      ranking={form.teamRanking}
+                      onChange={(ranking) => set("teamRanking", ranking)}
+                      availableTeamIds={campaign.teams}
+                      teamName={(id) => (campaign.teamInfo?.[id]?.name || TEAM_NAMES[id] || id)}
+                      iconMap={TEAM_ICONS}
+                      customTeam={form.customTeam}
+                      onCustomTeamChange={(val) => set("customTeam", val)}
+                    />
+                  )}
+                  {fieldEnabled("weeklyHours") && (
+                    <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-4">
+                        Weekly Availability
+                      </h3>
+                      <div className="flex items-start gap-4">
+                        <div className="flex-1 min-w-0">
+                          <input
+                            type="range"
+                            min={0}
+                            max={12}
+                            step={1}
+                            value={form.weeklyHours}
+                            onChange={(e) => set("weeklyHours", Number(e.target.value))}
+                            className="w-full accent-red-600 dark:accent-red-500"
+                          />
+                          {/* Labels aligned under the slider (this column only) */}
+                          <div className="flex justify-between text-xs text-gray-400 dark:text-gray-500 mt-1">
+                            <span>Casual</span>
+                            <span>Few hrs</span>
+                            <span>Committed</span>
+                            <span>Very active</span>
+                          </div>
+                        </div>
+                        <div className="shrink-0 min-w-[8rem] text-right pt-1">
+                          <span className="text-lg font-bold text-red-600 dark:text-red-400">
+                            {form.weeklyHours}
+                          </span>
+                          <span className="text-sm text-gray-500 dark:text-gray-400 ml-1">
+                            hour{form.weeklyHours !== 1 ? "s" : ""}/week
+                          </span>
                         </div>
                       </div>
-                      <div className="shrink-0 min-w-[8rem] text-right pt-1">
-                        <span className="text-lg font-bold text-red-600 dark:text-red-400">
-                          {form.weeklyHours}
-                        </span>
-                        <span className="text-sm text-gray-500 dark:text-gray-400 ml-1">
-                          hour{form.weeklyHours !== 1 ? "s" : ""}/week
-                        </span>
-                      </div>
                     </div>
-                  </div>
-                  <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-                    <FieldGroup label="Personal motivation" requiredHint="Required.">
-                      <TextareaBase
-                        placeholder="Tell us why you want to join UU AI Society and what you hope to contribute."
-                        value={form.motivation}
-                        onChange={(e) => set("motivation", e.target.value)}
-                        maxLength={MOTIVATION_MAX_CHARS}
-                        rows={5}
-                      />
-                    </FieldGroup>
-                    <p className={`text-xs mt-1 ${
-                      (form.motivation || "").length > MOTIVATION_MAX_CHARS ? "text-red-600" :
-                      (form.motivation || "").trim().length < 25 && (form.motivation || "").length > 0 ? "text-amber-600" :
-                      "text-gray-500"
-                    }`}>
-                      {(form.motivation || "").trim().length < 25 && (form.motivation || "").length > 0
-                        ? `Need ${25 - form.motivation.trim().length} more characters — `
-                        : ""
-                      }
-                      {(form.motivation || "").length} / {MOTIVATION_MAX_CHARS} characters
-                    </p>
-                  </div>
+                  )}
+                  {fieldEnabled("motivation") && (
+                    <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+                      <FieldGroup label="Personal motivation" requiredHint="Required.">
+                        <TextareaBase
+                          placeholder="Tell us why you want to join UU AI Society and what you hope to contribute."
+                          value={form.motivation}
+                          onChange={(e) => set("motivation", e.target.value)}
+                          maxLength={MOTIVATION_MAX_CHARS}
+                          rows={5}
+                        />
+                      </FieldGroup>
+                      <p className={`text-xs mt-1 ${
+                        (form.motivation || "").length > MOTIVATION_MAX_CHARS ? "text-red-600" :
+                        (form.motivation || "").trim().length < 25 && (form.motivation || "").length > 0 ? "text-amber-600" :
+                        "text-gray-500"
+                      }`}>
+                        {(form.motivation || "").trim().length < 25 && (form.motivation || "").length > 0
+                          ? `Need ${25 - form.motivation.trim().length} more characters — `
+                          : ""
+                        }
+                        {(form.motivation || "").length} / {MOTIVATION_MAX_CHARS} characters
+                      </p>
+                    </div>
+                  )}
                 </div>
               </Card>
             </div>
@@ -768,14 +857,15 @@ export default function TeamApplicationPage() {
                   <SummarySection icon={GraduationCap} title="Profile">
                     <SummaryRow label="Name" value={form.name} />
                     <SummaryRow label="Email" value={form.email} />
-                    <SummaryRow label="Gender" value={form.gender || "Prefer not to say"} />
-                    <SummaryRow label="University" value={form.university === "Uppsala" ? "Uppsala University" : form.university} />
-                    <SummaryRow label="Programme" value={form.program || "—"} />
-                    <SummaryRow label="Graduation year" value={form.expectedGraduationYear || "—"} />
+                    {fieldEnabled("gender") && <SummaryRow label="Gender" value={form.gender || "Prefer not to say"} />}
+                    {fieldEnabled("university") && <SummaryRow label="University" value={form.university === "Uppsala" ? "Uppsala University" : form.university} />}
+                    {fieldEnabled("program") && <SummaryRow label="Programme" value={form.program || "—"} />}
+                    {fieldEnabled("graduationYear") && <SummaryRow label="Graduation year" value={form.expectedGraduationYear || "—"} />}
                   </SummarySection>
                   <SummarySection icon={Briefcase} title="Experience & Interests">
-                    <SummaryRow label="LinkedIn" value={form.linkedin} />
-                    <SummaryRow label="Resume" value={form.resume?.name || "Not uploaded"} />
+                    {fieldEnabled("linkedin") && <SummaryRow label="LinkedIn" value={form.linkedin} />}
+                    {fieldEnabled("resume") && <SummaryRow label="Resume" value={form.resume?.name || "Not uploaded"} />}
+                    {fieldEnabled("interests") && (
                     <div className="flex flex-wrap gap-2 pt-1">
                       {form.interests.map((id) => {
                         const area = AREAS_OF_INTEREST.find((a) => a.id === id);
@@ -784,6 +874,7 @@ export default function TeamApplicationPage() {
                       {form.customInterest.trim() && <TagComponent key="custom-interest" variant="red" size="sm">{form.customInterest}</TagComponent>}
                       {form.interests.length === 0 && !form.customInterest.trim() && <span className="text-sm text-gray-400">No areas selected</span>}
                     </div>
+                    )}
                     {customQuestions.length > 0 && (
                       <div className="pt-2">
                         <span className="text-xs font-medium text-gray-500 uppercase">Additional answers</span>
@@ -801,7 +892,7 @@ export default function TeamApplicationPage() {
                     )}
                   </SummarySection>
                   <SummarySection icon={User} title="Team Selection">
-                    {form.teamRanking.map((team, idx) => (
+                    {fieldEnabled("teamRanking") && form.teamRanking.map((team, idx) => (
                       <div key={team.id} className="flex items-center gap-3 py-1">
                         <span className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-xs font-bold ${
                           idx === 0 ? "bg-red-600 text-white" : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
@@ -811,13 +902,15 @@ export default function TeamApplicationPage() {
                         <span className="text-sm text-gray-900 dark:text-white">{team.custom ? `${team.name}${form.customTeam ? `: ${form.customTeam}` : ""}` : team.name}</span>
                       </div>
                     ))}
-                    <SummaryRow label="Availability" value={`${form.weeklyHours} hour${form.weeklyHours !== 1 ? "s" : ""} per week`} />
+                    {fieldEnabled("weeklyHours") && <SummaryRow label="Availability" value={`${form.weeklyHours} hour${form.weeklyHours !== 1 ? "s" : ""} per week`} />}
+                    {fieldEnabled("motivation") && (
                     <div className="pt-2">
                       <span className="text-xs font-medium text-gray-500 uppercase">Motivation</span>
                       <p className="text-sm text-gray-900 dark:text-white whitespace-pre-wrap mt-1">
                         {form.motivation || "—"}
                       </p>
                     </div>
+                    )}
                   </SummarySection>
                   <label className="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300 pt-2 border-t border-gray-200 dark:border-gray-700">
                     <input type="checkbox" checked={form.agree} onChange={(e) => set("agree", e.target.checked)} className="mt-0.5 accent-red-600" />
@@ -834,8 +927,7 @@ export default function TeamApplicationPage() {
                       className="mt-0.5 accent-red-600"
                     />
                     <span>
-                      Also sign me up for the{" "}
-                      <Link href="/" className="text-blue-600 dark:text-blue-400 hover:underline">UU AI Society newsletter</Link>&nbsp;
+                      Also sign me up for the UU AI Society newsletter{" "}
                       <span className="text-gray-500 dark:text-gray-400">(optional)</span>
                     </span>
                   </label>

--- a/components/pages/TeamApplicationPage.tsx
+++ b/components/pages/TeamApplicationPage.tsx
@@ -1,0 +1,878 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import {
+  Sparkles, Clock, ChevronDown, Check,
+  Server, Code2,
+  Megaphone, CalendarDays, FlaskConical, Rocket, User,
+  GraduationCap, Briefcase, Tag, Lock, Loader2,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { FieldGroup, InputBase, SelectBase, TextareaBase } from "@/components/ui/Form";
+import FloatingSymbolsCanvas from "@/components/FloatingSymbolsCanvas";
+import MultiStepWizard, { WizardStep } from "@/components/ui/MultiStepWizard";
+import TeamRanker, { type TeamRankEntry } from "@/components/ui/TeamRanker";
+import { LinkedInUrlInput } from "@/components/ui/LinkedInUrlInput";
+import TagComponent from "@/components/ui/Tag";
+import PDFDropzone from "@/components/ui/PDFDropzone";
+import { useApp } from "@/contexts/AppContext";
+import { useNotify } from "@/components/ui/Notifications";
+import { auth } from "@/lib/firebase-client";
+import { getUserProfile, type UserProfile } from "@/lib/firestore/users";
+import { subscribeToCampaignQuestions } from "@/lib/firestore/campaignQuestions";
+import { getTeamApplicationByEmail } from "@/lib/firestore/teamApplications";
+import { ApplicationCampaign, CampaignQuestion } from "@/types";
+import {
+  UU_PROGRAMMES,
+  AREAS_OF_INTEREST,
+  MOTIVATION_MAX_CHARS,
+} from "./apply/sampleData";
+
+const TEAM_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  it: Server,
+  development: Code2,
+  growth: Megaphone,
+  partnerships_events: CalendarDays,
+  research: FlaskConical,
+  other: Rocket,
+};
+
+const WIZARD_STEPS: WizardStep[] = [
+  { key: "overview", title: "Overview" },
+  { key: "profile", title: "Your Profile" },
+  { key: "experience", title: "Experience" },
+  { key: "teams", title: "Team Selection" },
+  { key: "review", title: "Review" },
+];
+
+const TEAM_NAMES: Record<string, string> = {
+  it: "IT",
+  development: "Development",
+  growth: "Growth",
+  partnerships_events: "Partnerships & Events",
+  research: "Research",
+  other: "Other",
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface TeamFormData {
+  name: string;
+  email: string;
+  gender: string;
+  university: string;
+  program: string;
+  expectedGraduationYear: string;
+  linkedin: string;
+  resume: File | null;
+  interests: string[];
+  customInterest: string;
+  teamRanking: TeamRankEntry[];
+  customTeam: string;
+  weeklyHours: number;
+  motivation: string;
+  customAnswers: Record<string, string | string[]>;
+  agree: boolean;
+  newsletter: boolean;
+}
+
+const emptyForm: TeamFormData = {
+  name: "", email: "", gender: "", university: "Uppsala", program: "",
+  expectedGraduationYear: "", linkedin: "", resume: null,
+  interests: [], customInterest: "", teamRanking: [], customTeam: "", weeklyHours: 5,
+  motivation: "", customAnswers: {}, agree: false, newsletter: false,
+};
+
+export default function TeamApplicationPage() {
+  const { state } = useApp();
+  const { notify } = useNotify();
+  const router = useRouter();
+  const wizardRef = useRef<HTMLDivElement>(null);
+
+  // Find the first open campaign
+  const campaign: ApplicationCampaign | null = state.campaigns.find((c) => c.status === "open") || null;
+
+  const [step, setStep] = useState(0);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<TeamFormData>(emptyForm);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [customQuestions, setCustomQuestions] = useState<CampaignQuestion[]>([]);
+
+  // Check if the current user has already applied to this campaign
+  const [hasApplied, setHasApplied] = useState(false);
+  useEffect(() => {
+    if (!campaign?.id || !form.email) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setHasApplied(false);
+      return;
+    }
+    let cancelled = false;
+    const emailNorm = form.email.trim().toLowerCase();
+    // First check from reactive state if available (fast path)
+    if (state.teamApplications.some(
+      (a) => a.emailNormalized === emailNorm && a.campaignId === campaign.id
+    )) {
+      setHasApplied(true);
+      return;
+    }
+    // Fallback: direct Firestore query for non-admin users
+    getTeamApplicationByEmail(emailNorm, campaign.id).then((app) => {
+      if (!cancelled) setHasApplied(!!app);
+    });
+    return () => { cancelled = true; };
+  }, [campaign?.id, form.email, state.teamApplications]);
+
+
+  // Subscribe to custom questions for the active campaign
+  useEffect(() => {
+    if (!campaign?.id) return;
+    const unsub = subscribeToCampaignQuestions(campaign.id, (qs) => setCustomQuestions(qs));
+    return () => unsub();
+  }, [campaign?.id]);
+
+  // Prefill from auth profile
+  useEffect(() => {
+    const unsub = auth.onAuthStateChanged(async (user) => {
+      if (!user) { setAuthLoading(false); return; }
+      setForm((prev) => ({
+        ...prev,
+        name: prev.name || user.displayName || "",
+        email: prev.email || user.email || "",
+      }));
+      try {
+        const p = await getUserProfile(user.uid);
+        if (p) {
+          setProfile(p);
+          setForm((prev) => ({
+            ...prev,
+            name: prev.name || p.name || p.displayName || "",
+            email: prev.email || p.email || "",
+            gender: prev.gender || p.gender || "",
+            university: prev.university || p.university || "Uppsala",
+            program: prev.program || p.program || "",
+            expectedGraduationYear: prev.expectedGraduationYear || (p.expectedGraduationYear ? String(p.expectedGraduationYear) : ""),
+            linkedin: prev.linkedin || p.linkedin || "",
+          }));
+        }
+      } catch { /* ignore */ }
+      setAuthLoading(false);
+    });
+    return () => unsub();
+  }, []);
+
+  // Restore a pending application saved before login redirect
+  useEffect(() => {
+    if (authLoading) return;
+    const raw = sessionStorage.getItem("pendingApplication");
+    if (!raw) return;
+    try {
+      const saved = JSON.parse(raw) as Partial<TeamFormData>;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setForm((prev) => ({ ...prev, ...saved }));
+      sessionStorage.removeItem("pendingApplication");
+      // Jump to the experience step so they can re-attach their resume
+      setStep(2);
+      notify({ type: "info", title: "Application restored", message: "Please re-attach your resume before submitting." });
+    } catch {
+      sessionStorage.removeItem("pendingApplication");
+    }
+  }, [authLoading, notify]);
+
+  // Reset preferences whenever the campaign changes so stale rankings from a
+  // different campaign don't bleed in. The user will drag teams in step 4.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setForm((prev) => ({ ...prev, teamRanking: [], customTeam: "" }));
+  }, [campaign?.id]);
+
+  const set = <K extends keyof TeamFormData>(field: K, val: TeamFormData[K]) =>
+    setForm((p) => ({ ...p, [field]: val }));
+  const setCustom = (qId: string, val: string | string[]) =>
+    setForm((p) => ({ ...p, customAnswers: { ...p.customAnswers, [qId]: val } }));
+
+  const toggleInterest = (id: string) =>
+    setForm((p) => ({
+      ...p,
+      interests: p.interests.includes(id) ? p.interests.filter((i) => i !== id) : [...p.interests, id],
+    }));
+
+  const handleNext = () => {
+    setStep((s) => Math.min(s + 1, WIZARD_STEPS.length - 1));
+    setTimeout(() => wizardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 80);
+  };
+  const handleBack = () => {
+    setStep((s) => Math.max(s - 1, 0));
+    if (step === 1) setTimeout(() => window.scrollTo({ top: 0, behavior: "smooth" }), 80);
+  };
+
+  const handleSubmit = async () => {
+    if (!form.agree) return;
+    if (!campaign) return;
+    if (!auth.currentUser) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { resume: _resume, ...rest } = form;
+      sessionStorage.setItem("pendingApplication", JSON.stringify(rest));
+      router.push("/login?redirect=/apply/team");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const fd = new FormData();
+      fd.append("campaignId", campaign.id);
+      fd.append("name", form.name);
+      fd.append("email", form.email);
+      fd.append("gender", form.gender);
+      fd.append("university", form.university);
+      fd.append("program", form.program);
+      fd.append("graduationYear", form.expectedGraduationYear);
+      fd.append("linkedin", form.linkedin);
+      fd.append("customTeam", form.customTeam);
+      fd.append("weeklyHours", String(form.weeklyHours));
+      fd.append("motivation", form.motivation);
+      fd.append("agree", String(form.agree));
+      fd.append("newsletter", String(form.newsletter));
+      fd.append("interests", JSON.stringify(form.interests));
+      fd.append("customInterest", form.customInterest);
+      fd.append("teamRanking", JSON.stringify(form.teamRanking.map((t) => t.id)));
+      fd.append("customAnswers", JSON.stringify(form.customAnswers));
+      if (form.resume) fd.append("resume", form.resume, form.resume.name);
+
+      const res = await fetch("/api/applications", { method: "POST", body: fd });
+      const json = await res.json();
+      if (!res.ok) {
+        notify({ type: "error", title: "Submission failed", message: json?.error || "Unknown error" });
+        return;
+      }
+      setSubmitted(true);
+      notify({ type: "success", title: "Application submitted!", message: "We'll be in touch soon." });
+    } catch (err) {
+      console.error("Submit error", err);
+      notify({ type: "error", title: "Submission failed", message: "Network error. Please try again." });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // No open campaigns
+  if (state.campaigns.length > 0 && !campaign) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 pt-24 pb-12 transition-colors duration-300 flex items-center">
+        <div className="max-w-md mx-auto px-4 text-center">
+          <div className="w-16 h-16 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center mx-auto mb-6">
+            <Clock className="h-8 w-8 text-gray-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">No active campaigns</h1>
+          <p className="text-gray-600 dark:text-gray-300">There are no open application campaigns right now. Please check back later.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // No campaigns at all (loading or not configured)
+  if (!campaign) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 pt-24 pb-12 transition-colors duration-300 flex items-center">
+        <div className="max-w-md mx-auto px-4 text-center">
+          <Loader2 className="h-8 w-8 text-red-600 dark:text-red-400 animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-gray-400">Loading campaigns…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 pt-24 pb-12 transition-colors duration-300 flex items-center">
+        <div className="max-w-md mx-auto px-4 text-center">
+          <div className="w-20 h-20 rounded-full bg-green-100 dark:bg-green-950/30 flex items-center justify-center mx-auto mb-6">
+            <Check className="h-10 w-10 text-green-600 dark:text-green-400" />
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-3">Application Submitted!</h1>
+          <p className="text-gray-600 dark:text-gray-300 mb-6">
+            Thank you, {form.name.split(" ")[0] || "applicant"}. Your team application for{" "}
+            <strong className="text-red-600 dark:text-red-400">{campaign.title}</strong>&nbsp;has been received.
+            We&apos;ll contact you at {form.email || "your email"}.
+          </p>
+          <Link href="/">
+            <Button>Back to home</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Already applied to this campaign
+  if (hasApplied) {
+    return (
+      <div className="min-h-screen bg-white dark:bg-gray-900 pt-24 pb-12 transition-colors duration-300 flex items-center">
+        <div className="max-w-md mx-auto px-4 text-center">
+          <div className="w-20 h-20 rounded-full bg-blue-100 dark:bg-blue-950/30 flex items-center justify-center mx-auto mb-6">
+            <Check className="h-10 w-10 text-blue-600 dark:text-blue-400" />
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-3">Already Applied!</h1>
+          <p className="text-gray-600 dark:text-gray-300 mb-6">
+            You have already submitted an application for{" "}
+            <strong className="text-red-600 dark:text-red-400">{campaign.title}</strong>.
+            If you experienced any issues or need to update your submission, please email{" "}
+            <a href="mailto:dev@uuais.com" className="text-blue-600 dark:text-blue-400 hover:underline">dev@uuais.com</a>.
+          </p>
+          <Link href="/">
+            <Button variant="outline">Back to home</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // If not signed in, show login prompt (the form requires auth to POST)
+  if (!authLoading && !profile && !form.email) {
+    // Continue rendering — they can fill it but submission will require sign-in
+    // We'll show a small note reminding them to sign in
+  }
+
+  const canNext =
+    step === 0 ? true :
+    step === 1 ? !!form.name.trim() && EMAIL_RE.test(form.email.trim()) :
+    step === 2 ? !!form.linkedin.trim() && form.linkedin !== "https://" && (form.interests.length > 0 || !!form.customInterest.trim()) :
+    step === 3 ? form.motivation.trim().length >= 25 && form.teamRanking.length >= 1 :
+    true;
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-900 transition-colors duration-300">
+      {/* Hero header — full on step 0, compact on steps 1+ */}
+      {step === 0 ? (
+        <section className="relative bg-gradient-to-br from-red-600 via-red-700 to-red-800 dark:from-red-700 dark:via-red-800 dark:to-red-900 text-white min-h-[50vh] overflow-hidden">
+          <div className="absolute inset-0 bg-black/20 dark:bg-black/40" />
+          <FloatingSymbolsCanvas />
+          <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-16">
+            <p className="inline-flex items-center gap-2 text-red-200 dark:text-red-300 tracking-widest uppercase mb-6 font-semibold text-sm">
+              <Sparkles className="h-4 w-4" />
+              {campaign.subtitle}
+            </p>
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 leading-tight tracking-tight">
+              {campaign.title}
+            </h1>
+            <p className="text-lg md:text-xl text-red-100 dark:text-red-50 mb-6 max-w-2xl leading-relaxed">
+              {campaign.description}
+            </p>
+            <div className="flex items-center gap-2 text-red-100 dark:text-red-50">
+              <Clock className="h-5 w-5" />
+              <span>Application deadline: {campaign.deadline}</span>
+            </div>
+            <a href="#wizard" className="inline-block mt-10 animate-bounce">
+              <ChevronDown className="h-7 w-7 text-red-200 dark:text-red-300" />
+            </a>
+          </div>
+        </section>
+      ) : (
+        <section className="bg-gradient-to-r from-red-600 to-red-700 dark:from-red-700 dark:to-red-800 text-white">
+          <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-5 pt-28">
+            <h1 className="text-xl font-bold">{campaign.title}</h1>
+            <p className="text-sm text-red-100 dark:text-red-50">{campaign.subtitle}</p>
+          </div>
+        </section>
+      )}
+
+      {/* Wizard */}
+      <div ref={wizardRef} className="scroll-mt-24 py-12 bg-gray-50 dark:bg-gray-900 min-h-screen">
+        <MultiStepWizard
+          steps={WIZARD_STEPS}
+          currentStep={step}
+          onNext={handleNext}
+          onBack={handleBack}
+          onSubmit={handleSubmit}
+          canNext={canNext}
+          canBack={true}
+          submitLabel="Submit application"
+          submitDisabled={!form.agree || submitting}
+        >
+          {/* Step 0: Overview */}
+          {step === 0 && (
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">Who we&apos;re looking for</h2>
+                <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+                  We are looking for passionate students who are curious about AI, keen to learn, and
+                  excited to contribute to a vibrant community. No prior experience is required —
+                  enthusiasm and a willingness to grow are what matter most.
+                </p>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Our Teams</h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                  Explore the teams you can join. You&apos;ll rank your preferences in a later step.
+                </p>
+                <div className="grid gap-4">
+                  {campaign.teams.map((teamId) => {
+                    const teamOverride = campaign.teamInfo?.[teamId];
+                    const teamName = teamOverride?.name || TEAM_NAMES[teamId] || teamId;
+                    const teamDescription = teamOverride?.description || `Join the ${teamName} team and contribute to the society.`;
+                    const Icon = TEAM_ICONS[teamId] || Rocket;
+                    return (
+                      <Card key={teamId} className="group hover:shadow-lg transition-shadow duration-300">
+                        <div className="p-5 flex items-start gap-4">
+                          <div className="shrink-0 w-11 h-11 rounded-lg bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+                            <Icon className="h-5 w-5 text-red-600 dark:text-red-400" />
+                          </div>
+                          <div>
+                            <h4 className="font-semibold text-gray-900 dark:text-white mb-1">{teamName}</h4>
+                            <p className="text-sm text-gray-600 dark:text-gray-300">{teamDescription}</p>
+                          </div>
+                        </div>
+                      </Card>
+                    );
+                  })}
+                </div>
+              </div>
+              {!form.email && (
+                <div className="flex items-center gap-2 text-sm text-amber-700 dark:text-amber-500 bg-amber-50 dark:bg-amber-950/20 rounded-md p-3 border border-amber-200 dark:border-amber-800">
+                  <Lock className="h-4 w-4 shrink-0" />
+                  <span>
+                    You need to <Link href="/login" className="underline font-medium">sign in</Link> or{" "}
+                    <Link href="/join" className="underline font-medium">register</Link> to submit your application.
+                    You can still fill the form now and sign in before submitting.
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 1: Profile */}
+          {step === 1 && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">Your Profile</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2 flex items-center gap-1.5">
+                  <User className="h-4 w-4" />
+                  {profile ? "We've prefilled your details from your account." : "Please fill in your details."}
+                </p>
+              </div>
+              <Card>
+                <div className="p-6 space-y-5">
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <FieldGroup label="Full name" requiredHint="Required.">
+                      <InputBase maxLength={100} value={form.name} onChange={(e) => set("name", e.target.value)} />
+                    </FieldGroup>
+                    <FieldGroup label="Email" requiredHint="Required.">
+                      <InputBase type="email" maxLength={254} value={form.email} onChange={(e) => set("email", e.target.value)} />
+                    </FieldGroup>
+                  </div>
+                  <FieldGroup label="Gender" requiredHint="Optional.">
+                    <SelectBase value={form.gender} onChange={(e) => set("gender", e.target.value)}>
+                      <option value="">Prefer not to say</option>
+                      <option value="male">Male</option>
+                      <option value="female">Female</option>
+                      <option value="nonbinary">Non-binary</option>
+                      <option value="other">Other</option>
+                    </SelectBase>
+                  </FieldGroup>
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <FieldGroup label="University" requiredHint="Required if student.">
+                      <SelectBase value={form.university} onChange={(e) => set("university", e.target.value)}>
+                        <option value="Uppsala">Uppsala University</option>
+                        <option value="none">None</option>
+                        <option value="other">Other</option>
+                      </SelectBase>
+                    </FieldGroup>
+                    <FieldGroup label="Programme" requiredHint="Required if student.">
+                      <SelectBase value={form.program} onChange={(e) => set("program", e.target.value)}>
+                        <option value="">Select a programme</option>
+                        {UU_PROGRAMMES.map((prog) => (
+                          <option key={prog} value={prog}>{prog}</option>
+                        ))}
+                      </SelectBase>
+                    </FieldGroup>
+                  </div>
+                  <FieldGroup label="Expected graduation year" requiredHint="Optional">
+                    <InputBase
+                      type="number"
+                      min={1900}
+                      max={2100}
+                      maxLength={4}
+                      placeholder="e.g. 2027"
+                      value={form.expectedGraduationYear}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v.length <= 4) set("expectedGraduationYear", v);
+                      }}
+                    />
+                  </FieldGroup>
+                </div>
+              </Card>
+            </div>
+          )}
+
+          {/* Step 2: Experience */}
+          {step === 2 && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">Experience &amp; Interests</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                  Tell us about your professional presence and what areas of AI excite you.
+                </p>
+              </div>
+              <Card>
+                <div className="p-6 space-y-5">
+                  <FieldGroup label="LinkedIn URL" requiredHint="Required.">
+                    <LinkedInUrlInput value={form.linkedin} onChange={(v) => set("linkedin", v)} />
+                  </FieldGroup>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      Resume / CV (PDF, max 3MB) <span className="text-[11px] font-normal text-gray-500">Optional.</span>
+                    </label>
+                    <PDFDropzone
+                      file={form.resume}
+                      onChange={(f) => set("resume", f)}
+                      onError={(msg) => notify({ type: "error", title: "Resume upload", message: msg })}
+                    />
+                  </div>
+                  <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-1 mt-4">
+                      Areas of Interest
+                    </h3>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-3 flex items-center gap-1.5">
+                      <Tag className="h-3.5 w-3.5" /> Select at least one area that excites you.
+                    </p>
+                    <div className="space-y-2">
+                      {AREAS_OF_INTEREST.map((area) => {
+                        const checked = form.interests.includes(area.id);
+                        return (
+                          <label
+                            key={area.id}
+                            className={`flex items-center gap-3 px-4 py-2.5 rounded-lg border cursor-pointer transition-all duration-200 ${
+                              checked
+                                ? "border-red-600 bg-red-50 dark:bg-red-950/20"
+                                : "border-gray-200 dark:border-gray-700 hover:border-red-300 dark:hover:border-red-700"
+                            }`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() => toggleInterest(area.id)}
+                              className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
+                            />
+                            <span className={`text-sm font-medium ${checked ? "text-red-700 dark:text-red-400" : "text-gray-700 dark:text-gray-300"}`}>
+                              {area.label}
+                            </span>
+                          </label>
+                        );
+                      })}
+                      <label className={`flex items-center gap-3 px-4 py-2.5 rounded-lg border cursor-pointer transition-all duration-200 ${
+                        form.customInterest.trim()
+                          ? "border-red-600 bg-red-50 dark:bg-red-950/20"
+                          : "border-gray-200 dark:border-gray-700 hover:border-red-300 dark:hover:border-red-700"
+                      }`}>
+                        <input
+                          type="checkbox"
+                          checked={!!form.customInterest.trim()}
+                          onChange={() => {}}
+                          className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
+                        />
+                        <div className="flex-1 flex items-center gap-2">
+                          <span className="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">Other:</span>
+                          <input
+                            type="text"
+                            placeholder="Describe your area of interest"
+                            maxLength={200}
+                            value={form.customInterest}
+                            onChange={(e) => set("customInterest", e.target.value)}
+                            className="flex-1 px-2 py-1 text-sm rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                          />
+                        </div>
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-400 mt-3">
+                      {form.interests.length} area{form.interests.length !== 1 ? "s" : ""} selected
+                    </p>
+                  </div>
+
+                  {/* Custom questions */}
+                  {customQuestions.length > 0 && (
+                    <div className="pt-4 border-t border-gray-200 dark:border-gray-700 space-y-4">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
+                        Additional Questions
+                      </h3>
+                      {customQuestions.map((q) => (
+                        <div key={q.id}>
+                          {q.type === "text" && (
+                            <FieldGroup label={q.question} requiredHint={q.required ? "Required." : "Optional."}>
+                              <InputBase
+                                maxLength={500}
+                                value={(form.customAnswers[q.id] as string) || ""}
+                                onChange={(e) => setCustom(q.id, e.target.value)}
+                              />
+                            </FieldGroup>
+                          )}
+                          {q.type === "textarea" && (
+                            <FieldGroup label={q.question} requiredHint={q.required ? "Required." : "Optional."}>
+                              <TextareaBase
+                                rows={4}
+                                maxLength={2000}
+                                value={(form.customAnswers[q.id] as string) || ""}
+                                onChange={(e) => setCustom(q.id, e.target.value)}
+                              />
+                            </FieldGroup>
+                          )}
+                          {q.type === "select" && (
+                            <FieldGroup label={q.question} requiredHint={q.required ? "Required." : "Optional."}>
+                              <SelectBase
+                                value={(form.customAnswers[q.id] as string) || ""}
+                                onChange={(e) => setCustom(q.id, e.target.value)}
+                              >
+                                <option value="">Select an option</option>
+                                {q.options?.map((o) => <option key={o} value={o}>{o}</option>)}
+                              </SelectBase>
+                            </FieldGroup>
+                          )}
+                          {q.type === "radio" && (
+                            <div className="flex flex-col gap-2">
+                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                                {q.question} <span className="ml-1 text-[11px] font-normal text-gray-500">{q.required ? "Required." : "Optional."}</span>
+                              </span>
+                              {q.options?.map((o) => (
+                                <label key={o} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                                  <input type="radio" name={q.id} checked={form.customAnswers[q.id] === o} onChange={() => setCustom(q.id, o)} className="accent-red-600" />
+                                  {o}
+                                </label>
+                              ))}
+                            </div>
+                          )}
+                          {q.type === "checkbox" && (
+                            <div className="flex flex-col gap-2">
+                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                                {q.question} <span className="ml-1 text-[11px] font-normal text-gray-500">{q.required ? "Required." : "Optional."}</span>
+                              </span>
+                              <div className="flex flex-wrap gap-3">
+                                {q.options?.map((o) => {
+                                  const arr = (form.customAnswers[q.id] as string[]) || [];
+                                  return (
+                                    <label key={o} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                                      <input
+                                        type="checkbox"
+                                        checked={arr.includes(o)}
+                                        onChange={(e) => { if (e.target.checked) setCustom(q.id, [...arr, o]); else setCustom(q.id, arr.filter((a) => a !== o)); }}
+                                        className="accent-red-600"
+                                      />
+                                      {o}
+                                    </label>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </Card>
+            </div>
+          )}
+
+          {/* Step 3: Team Selection */}
+          {step === 3 && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">Team Selection</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                  Drag to rank teams by preference, set your availability, and tell us why you want to join.
+                </p>
+              </div>
+              <Card>
+                <div className="p-6 space-y-6">
+                  <TeamRanker
+                    ranking={form.teamRanking}
+                    onChange={(ranking) => set("teamRanking", ranking)}
+                    availableTeamIds={campaign.teams}
+                    teamName={(id) => (campaign.teamInfo?.[id]?.name || TEAM_NAMES[id] || id)}
+                    iconMap={TEAM_ICONS}
+                    customTeam={form.customTeam}
+                    onCustomTeamChange={(val) => set("customTeam", val)}
+                  />
+                  <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-4">
+                      Weekly Availability
+                    </h3>
+                    <div className="flex items-start gap-4">
+                      <div className="flex-1 min-w-0">
+                        <input
+                          type="range"
+                          min={0}
+                          max={12}
+                          step={1}
+                          value={form.weeklyHours}
+                          onChange={(e) => set("weeklyHours", Number(e.target.value))}
+                          className="w-full accent-red-600 dark:accent-red-500"
+                        />
+                        {/* Labels aligned under the slider (this column only) */}
+                        <div className="flex justify-between text-xs text-gray-400 dark:text-gray-500 mt-1">
+                          <span>Casual</span>
+                          <span>Few hrs</span>
+                          <span>Committed</span>
+                          <span>Very active</span>
+                        </div>
+                      </div>
+                      <div className="shrink-0 min-w-[8rem] text-right pt-1">
+                        <span className="text-lg font-bold text-red-600 dark:text-red-400">
+                          {form.weeklyHours}
+                        </span>
+                        <span className="text-sm text-gray-500 dark:text-gray-400 ml-1">
+                          hour{form.weeklyHours !== 1 ? "s" : ""}/week
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <FieldGroup label="Personal motivation" requiredHint="Required.">
+                      <TextareaBase
+                        placeholder="Tell us why you want to join UU AI Society and what you hope to contribute."
+                        value={form.motivation}
+                        onChange={(e) => set("motivation", e.target.value)}
+                        maxLength={MOTIVATION_MAX_CHARS}
+                        rows={5}
+                      />
+                    </FieldGroup>
+                    <p className={`text-xs mt-1 ${
+                      (form.motivation || "").length > MOTIVATION_MAX_CHARS ? "text-red-600" :
+                      (form.motivation || "").trim().length < 25 && (form.motivation || "").length > 0 ? "text-amber-600" :
+                      "text-gray-500"
+                    }`}>
+                      {(form.motivation || "").trim().length < 25 && (form.motivation || "").length > 0
+                        ? `Need ${25 - form.motivation.trim().length} more characters — `
+                        : ""
+                      }
+                      {(form.motivation || "").length} / {MOTIVATION_MAX_CHARS} characters
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </div>
+          )}
+
+          {/* Step 4: Review */}
+          {step === 4 && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">Review &amp; Submit</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                  Please review your application before submitting.
+                </p>
+              </div>
+              <Card>
+                <div className="p-6 space-y-5">
+                  <SummarySection icon={GraduationCap} title="Profile">
+                    <SummaryRow label="Name" value={form.name} />
+                    <SummaryRow label="Email" value={form.email} />
+                    <SummaryRow label="Gender" value={form.gender || "Prefer not to say"} />
+                    <SummaryRow label="University" value={form.university === "Uppsala" ? "Uppsala University" : form.university} />
+                    <SummaryRow label="Programme" value={form.program || "—"} />
+                    <SummaryRow label="Graduation year" value={form.expectedGraduationYear || "—"} />
+                  </SummarySection>
+                  <SummarySection icon={Briefcase} title="Experience & Interests">
+                    <SummaryRow label="LinkedIn" value={form.linkedin} />
+                    <SummaryRow label="Resume" value={form.resume?.name || "Not uploaded"} />
+                    <div className="flex flex-wrap gap-2 pt-1">
+                      {form.interests.map((id) => {
+                        const area = AREAS_OF_INTEREST.find((a) => a.id === id);
+                        return area ? <TagComponent key={id} variant="red" size="sm">{area.label}</TagComponent> : null;
+                      })}
+                      {form.customInterest.trim() && <TagComponent key="custom-interest" variant="red" size="sm">{form.customInterest}</TagComponent>}
+                      {form.interests.length === 0 && !form.customInterest.trim() && <span className="text-sm text-gray-400">No areas selected</span>}
+                    </div>
+                    {customQuestions.length > 0 && (
+                      <div className="pt-2">
+                        <span className="text-xs font-medium text-gray-500 uppercase">Additional answers</span>
+                        {customQuestions.map((q) => {
+                          const ans = form.customAnswers[q.id];
+                          const displayAns = Array.isArray(ans) ? ans.join(", ") : ans;
+                          return (
+                            <div key={q.id} className="mt-1">
+                              <span className="text-xs font-medium text-gray-500">{q.question}</span>
+                              <p className="text-sm text-gray-900 dark:text-white">{displayAns || "—"}</p>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </SummarySection>
+                  <SummarySection icon={User} title="Team Selection">
+                    {form.teamRanking.map((team, idx) => (
+                      <div key={team.id} className="flex items-center gap-3 py-1">
+                        <span className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-xs font-bold ${
+                          idx === 0 ? "bg-red-600 text-white" : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
+                        }`}>
+                          {idx + 1}
+                        </span>
+                        <span className="text-sm text-gray-900 dark:text-white">{team.custom ? `${team.name}${form.customTeam ? `: ${form.customTeam}` : ""}` : team.name}</span>
+                      </div>
+                    ))}
+                    <SummaryRow label="Availability" value={`${form.weeklyHours} hour${form.weeklyHours !== 1 ? "s" : ""} per week`} />
+                    <div className="pt-2">
+                      <span className="text-xs font-medium text-gray-500 uppercase">Motivation</span>
+                      <p className="text-sm text-gray-900 dark:text-white whitespace-pre-wrap mt-1">
+                        {form.motivation || "—"}
+                      </p>
+                    </div>
+                  </SummarySection>
+                  <label className="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300 pt-2 border-t border-gray-200 dark:border-gray-700">
+                    <input type="checkbox" checked={form.agree} onChange={(e) => set("agree", e.target.checked)} className="mt-0.5 accent-red-600" />
+                    <span>
+                      I confirm the information above is accurate and agree to the{" "}
+                      <Link href="/privacy" className="text-blue-600 dark:text-blue-400 hover:underline">Privacy Policy</Link>.
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+                    <input
+                      type="checkbox"
+                      checked={form.newsletter}
+                      onChange={(e) => set("newsletter", e.target.checked)}
+                      className="mt-0.5 accent-red-600"
+                    />
+                    <span>
+                      Also sign me up for the{" "}
+                      <Link href="/" className="text-blue-600 dark:text-blue-400 hover:underline">UU AI Society newsletter</Link>&nbsp;
+                      <span className="text-gray-500 dark:text-gray-400">(optional)</span>
+                    </span>
+                  </label>
+                  {submitting && (
+                    <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Submitting…
+                    </div>
+                  )}
+                </div>
+              </Card>
+            </div>
+          )}
+        </MultiStepWizard>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function SummarySection({ icon: Icon, title, children }: { icon: React.ComponentType<{ className?: string }>; title: string; children: React.ReactNode }) {
+  return (
+    <div className="pb-4 border-b border-gray-200 dark:border-gray-700 last:border-0 last:pb-0">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-3 flex items-center gap-2">
+        <Icon className="h-4 w-4 text-red-600 dark:text-red-400" />
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-3 gap-3 py-1">
+      <span className="text-xs font-medium text-gray-500 uppercase">{label}</span>
+      <span className="col-span-2 text-sm text-gray-900 dark:text-white">{value || "—"}</span>
+    </div>
+  );
+}

--- a/components/pages/admin/AdminDashboard.tsx
+++ b/components/pages/admin/AdminDashboard.tsx
@@ -48,6 +48,15 @@ const AdminDashboard: React.FC = () => {
     }
     return 'events';
   });
+  // Slide direction for the tab-content transition: content enters from the
+  // side the clicked tab is on relative to the currently active tab.
+  const [slideFrom, setSlideFrom] = useState<'right' | 'left'>('right');
+  const changeTab = (next: Tab) => {
+    const curIdx = tabValues.indexOf(activeTab);
+    const nextIdx = tabValues.indexOf(next);
+    setSlideFrom(nextIdx >= curIdx ? 'right' : 'left');
+    setActiveTab(next);
+  };
   const placeholderImage = '/images/logo-highdef.png';
 
   // Modal states
@@ -320,11 +329,11 @@ const AdminDashboard: React.FC = () => {
                 { key: 'jobs', label: 'Jobs', icon: BriefcaseBusiness },
                 { key: 'ai-settings', label: 'AI Settings', icon: Bot },
                 { key: 'applications', label: 'Applications', icon: Users },
-                { key: 'board-applications', label: "GA'26 Board Applications", icon: Users},
+                // { key: 'board-applications', label: "GA'26 Board Applications", icon: Users},
               ] as const).map(({ key, label, icon: Icon }) => (
                 <button
                   key={key}
-                  onClick={() => setActiveTab(key)}
+                  onClick={() => changeTab(key)}
                   className={`cursor-pointer flex items-center py-2 px-3 border-b-2 font-medium text-sm transition-all duration-200 ease-in-out ${activeTab === key
                     ? 'border-red-500 text-red-600 dark:text-red-400'
                     : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
@@ -340,6 +349,10 @@ const AdminDashboard: React.FC = () => {
 
         {/* Tab Content */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 md:p-6">
+          <div
+            key={activeTab}
+            className={`animate-in fade-in duration-300 ease-out ${slideFrom === 'right' ? 'slide-in-from-right-4' : 'slide-in-from-left-4'}`}
+          >
           {activeTab === 'events' && (
             <TabErrorBoundary name="Events">
               <EventsTab
@@ -418,10 +431,12 @@ const AdminDashboard: React.FC = () => {
                 onAddCampaign={() => { setEditingCampaign(null); setShowCampaignModal(true); }}
                 onEditCampaign={(c) => { setEditingCampaign(c); setShowCampaignModal(true); }}
                 onDeleteCampaign={handleDeleteCampaign}
+                onUpdateCampaignStatus={(id, status) => dispatch({ firestoreAction: 'UPDATE_CAMPAIGN', payload: { id, status } })}
                 onDeleteApplication={handleDeleteTeamApplication}
               />
             </TabErrorBoundary>
           )}
+          </div>
 
           {/* Blog Modal */}
           <BlogModal

--- a/components/pages/admin/AdminDashboard.tsx
+++ b/components/pages/admin/AdminDashboard.tsx
@@ -18,13 +18,15 @@ import TeamTab from '@/components/pages/admin/tabs/TeamTab';
 import BlogTab from '@/components/pages/admin/tabs/BlogTab';
 import FAQTab from '@/components/pages/admin/tabs/FAQTab';
 import BoardTab from '@/components/pages/admin/tabs/BoardTab'
+import ApplicationsTab from '@/components/pages/admin/tabs/ApplicationsTab';
 import AnalyticsTab from '@/components/pages/admin/tabs/AnalyticsTab';
 import FAQModal from '@/components/pages/admin/modals/FAQModal';
 import BlogModal from '@/components/pages/admin/modals/BlogModal';
 import BoardPositionModal, { type BPositionFormState } from './modals/BoardPositionModal';
+import CampaignBuilderModal from '@/components/pages/admin/modals/CampaignBuilderModal';
 import { useApp } from '@/contexts/AppContext';
 import { updatePageMeta } from '@/utils/seo';
-import { BlogPost, Event, TeamMember, FAQ, BoardPosition } from '@/types';
+import { BlogPost, Event, TeamMember, FAQ, BoardPosition, ApplicationCampaign } from '@/types';
 import MembersTab from '@/components/pages/admin/tabs/membersTab';
 import JobsTab from '@/components/pages/admin/tabs/JobsTab';
 import AISettingsTab from '@/components/pages/admin/tabs/AISettingsTab';
@@ -35,7 +37,7 @@ const AdminDashboard: React.FC = () => {
   const { state, dispatch } = useApp();
   const [nrUsers, setNrUsers] = useState<number>(0);
   //const { user, logout } = useAdmin();
-  const tabValues = ['events', 'team', 'blog', 'faq', 'analytics', 'members', 'jobs', 'ai-settings', 'board-applications'] as const;
+  const tabValues = ['events', 'team', 'blog', 'faq', 'analytics', 'members', 'jobs', 'ai-settings', 'applications', 'board-applications'] as const;
   type Tab = typeof tabValues[number];
   const [activeTab, setActiveTab] = useState<Tab>(() => {
     if (typeof window !== 'undefined') {
@@ -55,6 +57,8 @@ const AdminDashboard: React.FC = () => {
   const [editingItem, setEditingItem] = useState<Event | TeamMember | BlogPost | null>(null);
   const [editingFaq, setEditingFaq] = useState<FAQ | null>(null);
   const [editingBoardPosition, setEditingBoardPosition] = useState<BoardPosition | null>(null);
+  const [showCampaignModal, setShowCampaignModal] = useState(false);
+  const [editingCampaign, setEditingCampaign] = useState<ApplicationCampaign | null>(null);
   const [blogForm, setBlogForm] = useState({
     title: '',
     excerpt: '',
@@ -209,6 +213,32 @@ const AdminDashboard: React.FC = () => {
     dispatch({ firestoreAction: 'MOVE_BOARDPOS', payload: { positionId, direction } });
   };
 
+  const handleSaveCampaign = async (data: { id?: string; title: string; subtitle: string; description: string; deadline: string; status: 'open' | 'closed' | 'draft'; teams: string[]; teamInfo?: Record<string, { name?: string; description?: string }>; enabledStandardFields: string[] }): Promise<string | undefined> => {
+    if (data.id) {
+      // Update existing
+      dispatch({ firestoreAction: 'UPDATE_CAMPAIGN', payload: { id: data.id, title: data.title, subtitle: data.subtitle, description: data.description, deadline: data.deadline, status: data.status, teams: data.teams, teamInfo: data.teamInfo, enabledStandardFields: data.enabledStandardFields } as ApplicationCampaign });
+      return data.id;
+    } else {
+      // Add new — dispatch returns the doc id
+      const id = await dispatch({ firestoreAction: 'ADD_CAMPAIGN', payload: { title: data.title, subtitle: data.subtitle, description: data.description, deadline: data.deadline, status: data.status, teams: data.teams, teamInfo: data.teamInfo, enabledStandardFields: data.enabledStandardFields } });
+      return typeof id === 'string' ? id : undefined;
+    }
+  };
+
+  const handleDeleteCampaign = (id: string) => {
+    if (window.confirm('Delete this campaign and all its custom questions? Submissions will remain in Firestore.')) {
+      dispatch({ firestoreAction: 'DELETE_CAMPAIGN', payload: id });
+    }
+  };
+
+  const handleDeleteTeamApplication = (id: string, emailNormalized: string, campaignId: string) => {
+    if (window.confirm('Delete this submission?')) {
+      import('@/lib/firestore/teamApplications').then((mod) =>
+        mod.deleteTeamApplicationWithLimits(id, emailNormalized, campaignId)
+      ).catch(console.error);
+    }
+  };
+
   const handleEditBlogPost = (post: BlogPost) => {
     setEditingItem(post);
     setBlogForm({
@@ -289,6 +319,7 @@ const AdminDashboard: React.FC = () => {
                 { key: 'members', label: 'Members', icon: Users },
                 { key: 'jobs', label: 'Jobs', icon: BriefcaseBusiness },
                 { key: 'ai-settings', label: 'AI Settings', icon: Bot },
+                { key: 'applications', label: 'Applications', icon: Users },
                 { key: 'board-applications', label: "GA'26 Board Applications", icon: Users},
               ] as const).map(({ key, label, icon: Icon }) => (
                 <button
@@ -379,6 +410,18 @@ const AdminDashboard: React.FC = () => {
               <AISettingsTab />
             </TabErrorBoundary>
           )}
+          {activeTab === 'applications' && (
+            <TabErrorBoundary name="Applications">
+              <ApplicationsTab
+                campaigns={state.campaigns}
+                applications={state.teamApplications}
+                onAddCampaign={() => { setEditingCampaign(null); setShowCampaignModal(true); }}
+                onEditCampaign={(c) => { setEditingCampaign(c); setShowCampaignModal(true); }}
+                onDeleteCampaign={handleDeleteCampaign}
+                onDeleteApplication={handleDeleteTeamApplication}
+              />
+            </TabErrorBoundary>
+          )}
 
           {/* Blog Modal */}
           <BlogModal
@@ -414,6 +457,14 @@ const AdminDashboard: React.FC = () => {
             editing={!!editingBoardPosition}
             onAdd={handleAddBoardPosition}
             onUpdate={handleUpdateBoardPosition}
+          />
+
+          <CampaignBuilderModal
+            open={showCampaignModal}
+            campaign={editingCampaign}
+            isNew={!editingCampaign}
+            onClose={() => { setShowCampaignModal(false); setEditingCampaign(null); }}
+            onSaveCampaign={handleSaveCampaign}
           />
 
         </div>

--- a/components/pages/admin/modals/CampaignBuilderModal.tsx
+++ b/components/pages/admin/modals/CampaignBuilderModal.tsx
@@ -156,6 +156,13 @@ const CampaignBuilderModal: React.FC<Props> = ({ open, campaign, isNew, onClose,
       return next;
     });
 
+  const addOption = (id: string) =>
+    setQuestions((prev) => prev.map((q) => (q.id === id ? { ...q, options: [...q.options, ""] } : q)));
+  const updateOption = (id: string, idx: number, value: string) =>
+    setQuestions((prev) => prev.map((q) => (q.id === id ? { ...q, options: q.options.map((o, i) => (i === idx ? value : o)) } : q)));
+  const removeOption = (id: string, idx: number) =>
+    setQuestions((prev) => prev.map((q) => (q.id === id ? { ...q, options: q.options.filter((_, i) => i !== idx) } : q)));
+
   const hasOptions = (t: CustomQuestionType) => t === "select" || t === "radio" || t === "checkbox";
   const STANDARD_FIELDS = [
     { id: "name", label: "Full name" },
@@ -195,30 +202,25 @@ const CampaignBuilderModal: React.FC<Props> = ({ open, campaign, isNew, onClose,
         // Delete removed questions
         await Promise.all(removedQuestionIds.map((qid) => deleteCampaignQuestion(qid).catch(() => {})));
 
-        // Upsert remaining questions with fresh order
-        for (let i = 0; i < questions.length; i++) {
-          const q = questions[i];
-          if (!q.question.trim()) continue;
-          const isNewQuestion = q.id.startsWith("new_");
-          if (isNewQuestion) {
-            await addCampaignQuestion({
-              campaignId: targetCampaignId,
-              question: q.question.trim(),
-              type: q.type,
-              options: hasOptions(q.type) ? q.options : [],
-              required: q.required,
-              order: i,
-            });
-          } else {
-            await updateCampaignQuestion(q.id, {
-              question: q.question.trim(),
-              type: q.type,
-              options: hasOptions(q.type) ? q.options : [],
-              required: q.required,
-              order: i,
-            });
-          }
-        }
+        // Upsert remaining questions with fresh order (each write sets its own
+        // order explicitly, so they can be issued in parallel).
+        const upserts: Promise<string | void>[] = [];
+        questions.forEach((q, i) => {
+          if (!q.question.trim()) return;
+          const payload = {
+            question: q.question.trim(),
+            type: q.type,
+            options: hasOptions(q.type) ? q.options.filter((o) => o.trim() !== "") : [],
+            required: q.required,
+            order: i,
+          };
+          upserts.push(
+            q.id.startsWith("new_")
+              ? addCampaignQuestion({ campaignId: targetCampaignId, ...payload })
+              : updateCampaignQuestion(q.id, payload)
+          );
+        });
+        await Promise.all(upserts);
       }
 
       notify({ type: "success", title: isNew ? "Campaign created" : "Campaign updated", message: isNew ? "The campaign is now available." : "Changes saved." });
@@ -233,11 +235,11 @@ const CampaignBuilderModal: React.FC<Props> = ({ open, campaign, isNew, onClose,
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/50 dark:bg-black/70" onClick={onClose} aria-hidden />
+      <div className="absolute inset-0 bg-black/50 dark:bg-black/70 animate-in fade-in duration-300" onClick={onClose} aria-hidden />
       <div
         role="dialog"
         aria-modal="true"
-        className="relative w-full max-w-3xl max-h-[92vh] overflow-y-auto rounded-lg bg-white dark:bg-gray-800 shadow-2xl"
+        className="relative w-full max-w-3xl max-h-[92vh] overflow-y-auto rounded-lg bg-white dark:bg-gray-800 shadow-2xl animate-in fade-in zoom-in-95 duration-300 ease-out"
       >
         {/* Header */}
         <div className="sticky top-0 z-10 flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
@@ -316,7 +318,7 @@ const CampaignBuilderModal: React.FC<Props> = ({ open, campaign, isNew, onClose,
               {enabledTeams.length > 0 && (
                 <div className="mt-4 space-y-3">
                   <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Customise the team name and description shown to applicants in step 1. Leave blank to use the default.
+                    Customize the team name and description shown to applicants in step 1. Leave blank to use the default.
                   </p>
                   {enabledTeams.map((id) => {
                     const info = teamInfo[id] || {};
@@ -431,21 +433,40 @@ const CampaignBuilderModal: React.FC<Props> = ({ open, campaign, isNew, onClose,
                           </label>
                           {hasOptions(q.type) && (
                             <button type="button" onClick={() => toggleOptionsExpanded(q.id)} className="text-xs text-blue-600 dark:text-blue-400 hover:underline">
-                              {expanded ? "Hide options" : `Options (${q.options.length})`}
+                              {expanded ? "Hide options" : `Options (${q.options.filter((o) => o.trim() !== "").length})`}
                             </button>
                           )}
                         </div>
                         {hasOptions(q.type) && expanded && (
-                          <div className="pl-7 mt-3">
-                            <textarea
-                              maxLength={2000}
-                              placeholder="One option per line (e.g. Yes&#10;No&#10;Maybe)"
-                              value={q.options.join("\n")}
-                              onChange={(e) => updateQuestion(q.id, { options: e.target.value.split("\n").filter((o) => o.trim() !== "") })}
-                              rows={4}
-                              className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
-                            />
-                            <p className="text-xs text-gray-400 mt-1">Type one option per line. These will appear as {q.type === "checkbox" ? "checkboxes" : q.type === "radio" ? "radio buttons" : "dropdown options"}.</p>
+                          <div className="pl-7 mt-3 space-y-2">
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                              Each option appears as a {q.type === "checkbox" ? "checkbox" : q.type === "radio" ? "single choice" : "dropdown option"} in the applicant form.
+                            </p>
+                            <ul className="space-y-2">
+                              {q.options.map((opt, oi) => (
+                                <li key={oi} className="flex items-center gap-2">
+                                  <InputBase
+                                    maxLength={200}
+                                    placeholder={`Option ${oi + 1}`}
+                                    value={opt}
+                                    onChange={(e) => updateOption(q.id, oi, e.target.value)}
+                                    ref={(el) => { if (el && oi === q.options.length - 1 && opt === "") el.focus(); }}
+                                  />
+                                  <button
+                                    type="button"
+                                    onClick={() => removeOption(q.id, oi)}
+                                    title="Remove option"
+                                    aria-label={`Remove option ${oi + 1}`}
+                                    className="p-1.5 text-red-500 hover:text-red-600 transition-colors cursor-pointer"
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                            <Button type="button" size="sm" variant="outline" icon={Plus} onClick={() => addOption(q.id)}>
+                              Create new option
+                            </Button>
                           </div>
                         )}
                       </div>

--- a/components/pages/admin/modals/CampaignBuilderModal.tsx
+++ b/components/pages/admin/modals/CampaignBuilderModal.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { X, Plus, Trash2, GripVertical, ArrowUp, ArrowDown, FileQuestion } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { FieldGroup, InputBase, TextareaBase, SelectBase } from "@/components/ui/Form";
+import {
+  ApplicationCampaign, CampaignStatus, CustomQuestionType, CampaignQuestion,
+} from "@/types";
+import {
+  getCampaignQuestions, addCampaignQuestion, updateCampaignQuestion,
+  deleteCampaignQuestion,
+} from "@/lib/firestore/campaignQuestions";
+import { useNotify } from "@/components/ui/Notifications";
+
+const QUESTION_TYPES: { value: CustomQuestionType; label: string }[] = [
+  { value: "text", label: "Short text" },
+  { value: "textarea", label: "Long text" },
+  { value: "select", label: "Dropdown" },
+  { value: "radio", label: "Single choice" },
+  { value: "checkbox", label: "Multiple choice" },
+];
+
+const TEAM_IDS = ["it", "development", "growth", "partnerships_events", "research"];
+const TEAM_NAME: Record<string, string> = {
+  it: "IT", development: "Development", growth: "Growth",
+  partnerships_events: "Partnerships & Events", research: "Research",
+};
+
+interface QDraft {
+  id: string;
+  question: string;
+  type: CustomQuestionType;
+  options: string[];
+  required: boolean;
+}
+
+let qSeq = 1;
+const newQId = () => `new_${Date.now()}_${qSeq++}`;
+
+function toDrafts(qs: CampaignQuestion[]): QDraft[] {
+  return [...qs]
+    .sort((a, b) => a.order - b.order)
+    .map((q) => ({ id: q.id, question: q.question, type: q.type, options: q.options || [], required: q.required }));
+}
+
+interface Props {
+  open: boolean;
+  campaign?: ApplicationCampaign | null;
+  isNew?: boolean;
+  onClose: () => void;
+  onSaveCampaign: (data: { id?: string; title: string; subtitle: string; description: string; deadline: string; status: CampaignStatus; teams: string[]; teamInfo?: Record<string, { name?: string; description?: string }>; enabledStandardFields: string[] }) => Promise<string | undefined | void>;
+}
+
+const CampaignBuilderModal: React.FC<Props> = ({ open, campaign, isNew, onClose, onSaveCampaign }) => {
+  const { notify } = useNotify();
+  const [title, setTitle] = useState("");
+  const [subtitle, setSubtitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [deadline, setDeadline] = useState("");
+  const [status, setStatus] = useState<CampaignStatus>("draft");
+  const [enabledTeams, setEnabledTeams] = useState<string[]>([]);
+  const [teamInfo, setTeamInfo] = useState<Record<string, { name?: string; description?: string }>>({});
+  const [enabledStandardFields, setEnabledStandardFields] = useState<string[]>([
+    "name", "email", "gender", "university", "program", "graduationYear",
+    "linkedin", "resume", "interests", "teamRanking", "weeklyHours", "motivation",
+  ]);
+  const [questions, setQuestions] = useState<QDraft[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [optionsExpanded, setOptionsExpanded] = useState<Set<string>>(new Set());
+  const [removedQuestionIds, setRemovedQuestionIds] = useState<string[]>([]);
+
+  // Load campaign data + questions when opening
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTitle(campaign?.title ?? "");
+     
+    setSubtitle(campaign?.subtitle ?? "");
+     
+    setDescription(campaign?.description ?? "");
+     
+    setDeadline(campaign?.deadline ?? "");
+     
+    setStatus(campaign?.status ?? "draft");
+     
+    setEnabledTeams(campaign?.teams ?? []);
+
+    setTeamInfo(campaign?.teamInfo ? { ...campaign.teamInfo } : {});
+     
+    setEnabledStandardFields(campaign?.enabledStandardFields?.length ? campaign.enabledStandardFields : [
+      "name", "email", "gender", "university", "program", "graduationYear",
+      "linkedin", "resume", "interests", "teamRanking", "weeklyHours", "motivation",
+    ]);
+     
+    setRemovedQuestionIds([]);
+     
+    setOptionsExpanded(new Set());
+
+    if (campaign?.id && !isNew) {
+      setLoading(true);
+      getCampaignQuestions(campaign.id)
+        .then((qs) => { setQuestions(toDrafts(qs)); })
+        .catch((e) => { console.error("Failed to load campaign questions", e); setQuestions([]); })
+        .finally(() => setLoading(false));
+    } else {
+       
+      setQuestions([]);
+    }
+  }, [open, campaign, isNew]);
+
+  if (!open) return null;
+
+  const toggleTeam = (id: string) =>
+    setEnabledTeams((prev) => prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]);
+  const toggleField = (id: string) =>
+    setEnabledStandardFields((prev) => prev.includes(id) ? prev.filter((f) => f !== id) : [...prev, id]);
+  const setTeamNameByUser = (id: string, value: string) =>
+    setTeamInfo((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], name: value || undefined },
+    }));
+  const setTeamDescription = (id: string, value: string) =>
+    setTeamInfo((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], description: value || undefined },
+    }));
+
+  const addQuestion = () =>
+    setQuestions((prev) => [...prev, { id: newQId(), question: "", type: "text", options: [], required: false }]);
+  const removeQuestion = (id: string) => {
+    setQuestions((prev) => prev.filter((q) => q.id !== id));
+    // Mark for deletion from Firestore if it existed there (id is not a temp id)
+    if (campaign?.id && !id.startsWith("new_")) {
+      setRemovedQuestionIds((prev) => [...prev, id]);
+    }
+  };
+  const moveQuestion = (id: string, dir: -1 | 1) =>
+    setQuestions((prev) => {
+      const idx = prev.findIndex((q) => q.id === id);
+      if (idx < 0) return prev;
+      const newIdx = idx + dir;
+      if (newIdx < 0 || newIdx >= prev.length) return prev;
+      const next = [...prev];
+      [next[idx], next[newIdx]] = [next[newIdx], next[idx]];
+      return next;
+    });
+  const updateQuestion = (id: string, patch: Partial<QDraft>) =>
+    setQuestions((prev) => prev.map((q) => (q.id === id ? { ...q, ...patch } : q)));
+  const toggleOptionsExpanded = (id: string) =>
+    setOptionsExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const hasOptions = (t: CustomQuestionType) => t === "select" || t === "radio" || t === "checkbox";
+  const STANDARD_FIELDS = [
+    { id: "name", label: "Full name" },
+    { id: "email", label: "Email" },
+    { id: "gender", label: "Gender" },
+    { id: "university", label: "University" },
+    { id: "program", label: "Programme" },
+    { id: "graduationYear", label: "Expected graduation year" },
+    { id: "linkedin", label: "LinkedIn URL" },
+    { id: "resume", label: "Resume / CV upload" },
+    { id: "interests", label: "Areas of interest" },
+    { id: "teamRanking", label: "Team preference ranking" },
+    { id: "weeklyHours", label: "Weekly availability" },
+    { id: "motivation", label: "Personal motivation" },
+  ];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || enabledTeams.length === 0) return;
+    setSaving(true);
+    try {
+      const campaignId = await onSaveCampaign({
+        id: campaign?.id,
+        title: title.trim(),
+        subtitle: subtitle.trim(),
+        description: description.trim(),
+        deadline,
+        status,
+        teams: enabledTeams,
+        teamInfo,
+        enabledStandardFields,
+      });
+
+      // Save custom questions (only if we have a campaign id — either editing existing or just created)
+      const targetCampaignId = (typeof campaignId === 'string' ? campaignId : undefined) || campaign?.id;
+      if (targetCampaignId) {
+        // Delete removed questions
+        await Promise.all(removedQuestionIds.map((qid) => deleteCampaignQuestion(qid).catch(() => {})));
+
+        // Upsert remaining questions with fresh order
+        for (let i = 0; i < questions.length; i++) {
+          const q = questions[i];
+          if (!q.question.trim()) continue;
+          const isNewQuestion = q.id.startsWith("new_");
+          if (isNewQuestion) {
+            await addCampaignQuestion({
+              campaignId: targetCampaignId,
+              question: q.question.trim(),
+              type: q.type,
+              options: hasOptions(q.type) ? q.options : [],
+              required: q.required,
+              order: i,
+            });
+          } else {
+            await updateCampaignQuestion(q.id, {
+              question: q.question.trim(),
+              type: q.type,
+              options: hasOptions(q.type) ? q.options : [],
+              required: q.required,
+              order: i,
+            });
+          }
+        }
+      }
+
+      notify({ type: "success", title: isNew ? "Campaign created" : "Campaign updated", message: isNew ? "The campaign is now available." : "Changes saved." });
+      onClose();
+    } catch (err) {
+      console.error("Save campaign error", err);
+      notify({ type: "error", title: "Save failed", message: "Could not save campaign. Please try again." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50 dark:bg-black/70" onClick={onClose} aria-hidden />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-3xl max-h-[92vh] overflow-y-auto rounded-lg bg-white dark:bg-gray-800 shadow-2xl"
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+          <div className="flex items-center gap-2">
+            <FileQuestion className="h-5 w-5 text-red-600 dark:text-red-400" />
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white">
+              {isNew ? "New campaign" : `Edit: ${campaign?.title}`}
+            </h2>
+          </div>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
+            <X className="h-6 w-6" />
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="p-12 text-center text-gray-500 dark:text-gray-400">
+            <div className="h-6 w-6 border-2 border-red-600 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+            Loading campaign…
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-6 p-6">
+            {/* Metadata */}
+            <section>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-4">Campaign details</h3>
+              <div className="grid gap-4">
+                <FieldGroup label="Campaign title" requiredHint="Required.">
+                  <InputBase maxLength={150} placeholder="e.g. Spring 2026 Recruitment" value={title} onChange={(e) => setTitle(e.target.value)} />
+                </FieldGroup>
+                <FieldGroup label="Subtitle" requiredHint="Optional.">
+                  <InputBase maxLength={300} placeholder="e.g. UU AI Society — Spring 2026" value={subtitle} onChange={(e) => setSubtitle(e.target.value)} />
+                </FieldGroup>
+                <FieldGroup label="Description" requiredHint="Shown to applicants on step 1.">
+                  <TextareaBase maxLength={2000} placeholder="Describe who you're looking for and what this campaign is about." value={description} onChange={(e) => setDescription(e.target.value)} rows={4} />
+                </FieldGroup>
+                <div className="grid md:grid-cols-2 gap-4">
+                  <FieldGroup label="Application deadline" requiredHint="Required.">
+                    <InputBase type="date" value={deadline} onChange={(e) => setDeadline(e.target.value)} />
+                  </FieldGroup>
+                  <FieldGroup label="Status" requiredHint="Controls visibility.">
+                    <SelectBase value={status} onChange={(e) => setStatus(e.target.value as CampaignStatus)}>
+                      <option value="draft">Draft (not visible)</option>
+                      <option value="open">Open (accepting submissions)</option>
+                      <option value="closed">Closed (read-only)</option>
+                    </SelectBase>
+                  </FieldGroup>
+                </div>
+              </div>
+            </section>
+
+            {/* Team selection */}
+            <section className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-1 mt-4">Teams available in this campaign</h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">Applicants will rank the selected teams in step 4.</p>
+              <div className="flex flex-wrap gap-2">
+                {TEAM_IDS.map((id) => {
+                  const enabled = enabledTeams.includes(id);
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => toggleTeam(id)}
+                      className={`px-3 py-2 rounded-lg border text-sm font-medium transition-all duration-200 ${
+                        enabled ? "border-red-600 bg-red-600 text-white shadow-sm" : "border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600"
+                      }`}
+                    >
+                      {TEAM_NAME[id]}
+                    </button>
+                  );
+                })}
+              </div>
+              {enabledTeams.length === 0 && (
+                <p className="text-xs text-amber-600 dark:text-amber-500 mt-2">Select at least one team.</p>
+              )}
+
+              {/* Per-team flavor text overrides (shown only when teams are selected) */}
+              {enabledTeams.length > 0 && (
+                <div className="mt-4 space-y-3">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Customise the team name and description shown to applicants in step 1. Leave blank to use the default.
+                  </p>
+                  {enabledTeams.map((id) => {
+                    const info = teamInfo[id] || {};
+                    return (
+                      <div key={id} className="border border-gray-200 dark:border-gray-700 rounded-md p-3 bg-gray-50/50 dark:bg-gray-900/30">
+                        <div className="flex items-center gap-2 mb-2">
+                          <span className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase">{TEAM_NAME[id]} (override)</span>
+                        </div>
+                        <div className="grid gap-2">
+                          <InputBase
+                            maxLength={100}
+                            placeholder={`Custom name (default: ${TEAM_NAME[id]})`}
+                            value={info.name || ""}
+                            onChange={(e) => setTeamNameByUser(id, e.target.value)}
+                          />
+                          <TextareaBase
+                            maxLength={500}
+                            placeholder="Custom description shown under the team name in step 1"
+                            rows={2}
+                            value={info.description || ""}
+                            onChange={(e) => setTeamDescription(id, e.target.value)}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+
+            {/* Standard fields */}
+            <section className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-1 mt-4">Standard applicant fields</h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">Toggle which fields appear in the applicant form.</p>
+              <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-2">
+                {STANDARD_FIELDS.map((field) => {
+                  const enabled = enabledStandardFields.includes(field.id);
+                  return (
+                    <label
+                      key={field.id}
+                      className={`flex items-center gap-2 p-2.5 rounded-md border text-sm cursor-pointer transition-colors ${
+                        enabled ? "border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/20" : "border-gray-200 dark:border-gray-700"
+                      }`}
+                    >
+                      <input type="checkbox" checked={enabled} onChange={() => toggleField(field.id)} className="accent-red-600" />
+                      <span className="text-gray-700 dark:text-gray-300">{field.label}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </section>
+
+            {/* Custom questions builder */}
+            <section className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-between mb-1 mt-4">
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">Custom questions</h3>
+                <Button type="button" size="sm" variant="outline" icon={Plus} onClick={addQuestion}>Add question</Button>
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">Add custom questions unique to this campaign. They appear in the applicant form after the standard fields.</p>
+
+              {questions.length === 0 ? (
+                <div className="text-center py-8 text-sm text-gray-400 dark:text-gray-500 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-md">
+                  No custom questions yet. Click &ldquo;Add question&rdquo; to create one.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {questions.map((q, idx) => {
+                    const expanded = optionsExpanded.has(q.id);
+                    return (
+                      <div key={q.id} className="border border-gray-200 dark:border-gray-700 rounded-md p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                        <div className="flex items-start gap-2 mb-3">
+                          <div className="shrink-0 flex flex-col items-center pt-1">
+                            <GripVertical className="h-4 w-4 text-gray-300 dark:text-gray-600" />
+                            <span className="text-xs font-bold text-gray-400 mt-0.5">{idx + 1}</span>
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <InputBase
+                              maxLength={500}
+                              placeholder="Question text"
+                              value={q.question}
+                              onChange={(e) => updateQuestion(q.id, { question: e.target.value })}
+                            />
+                          </div>
+                          <div className="shrink-0 flex items-center gap-0.5">
+                            <button type="button" onClick={() => moveQuestion(q.id, -1)} disabled={idx === 0} className="p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30 transition-colors" title="Move up">
+                              <ArrowUp className="h-4 w-4" />
+                            </button>
+                            <button type="button" onClick={() => moveQuestion(q.id, 1)} disabled={idx === questions.length - 1} className="p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30 transition-colors" title="Move down">
+                              <ArrowDown className="h-4 w-4" />
+                            </button>
+                            <button type="button" onClick={() => removeQuestion(q.id)} className="p-1.5 text-red-500 hover:text-red-600 transition-colors" title="Delete question">
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-3 pl-7">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Type:</span>
+                            <SelectBase
+                              value={q.type}
+                              onChange={(e) => updateQuestion(q.id, { type: e.target.value as CustomQuestionType })}
+                              className="w-36 py-1 text-sm"
+                            >
+                              {QUESTION_TYPES.map((t) => (
+                                <option key={t.value} value={t.value}>{t.label}</option>
+                              ))}
+                            </SelectBase>
+                          </div>
+                          <label className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
+                            <input type="checkbox" checked={q.required} onChange={(e) => updateQuestion(q.id, { required: e.target.checked })} className="accent-red-600" />
+                            Required
+                          </label>
+                          {hasOptions(q.type) && (
+                            <button type="button" onClick={() => toggleOptionsExpanded(q.id)} className="text-xs text-blue-600 dark:text-blue-400 hover:underline">
+                              {expanded ? "Hide options" : `Options (${q.options.length})`}
+                            </button>
+                          )}
+                        </div>
+                        {hasOptions(q.type) && expanded && (
+                          <div className="pl-7 mt-3">
+                            <textarea
+                              maxLength={2000}
+                              placeholder="One option per line (e.g. Yes&#10;No&#10;Maybe)"
+                              value={q.options.join("\n")}
+                              onChange={(e) => updateQuestion(q.id, { options: e.target.value.split("\n").filter((o) => o.trim() !== "") })}
+                              rows={4}
+                              className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                            />
+                            <p className="text-xs text-gray-400 mt-1">Type one option per line. These will appear as {q.type === "checkbox" ? "checkboxes" : q.type === "radio" ? "radio buttons" : "dropdown options"}.</p>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+
+            {/* Footer */}
+            <div className="flex justify-between items-center pt-4 border-t border-gray-200 dark:border-gray-700">
+              <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
+              <Button type="submit" disabled={!title.trim() || enabledTeams.length === 0 || saving}>
+                {saving ? "Saving…" : isNew ? "Create campaign" : "Save changes"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CampaignBuilderModal;

--- a/components/pages/admin/tabs/ApplicationsTab.tsx
+++ b/components/pages/admin/tabs/ApplicationsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import {
   Plus, Edit3, Trash2, Eye, ChevronDown, ChevronUp, Calendar,
   Users, FileQuestion, Search, ArrowLeft,
@@ -9,8 +9,9 @@ import {
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import Tag from "@/components/ui/Tag";
-import { InputBase } from "@/components/ui/Form";
+import { InputBase, SelectBase } from "@/components/ui/Form";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import { subscribeToCampaignQuestions } from "@/lib/firestore/campaignQuestions";
 import {
   ApplicationCampaign, TeamApplication, CampaignStatus,
 } from "@/types";
@@ -27,6 +28,14 @@ const STATUS_STYLES: Record<CampaignStatus, { label: string; tagVariant: "green"
   open: { label: "Open", tagVariant: "green" },
   closed: { label: "Closed", tagVariant: "red" },
   draft: { label: "Draft", tagVariant: "yellow" },
+};
+
+const STATUS_ORDER: CampaignStatus[] = ["open", "draft", "closed"];
+
+const STATUS_TOGGLE_ACTIVE: Record<CampaignStatus, string> = {
+  open: "bg-green-600 text-white border-green-600",
+  draft: "bg-yellow-500 text-white border-yellow-500",
+  closed: "bg-gray-600 text-white border-gray-600",
 };
 
 const formatDate = (createdAt: TeamApplication["createdAt"]): string => {
@@ -54,11 +63,12 @@ interface ApplicationsTabProps {
   onAddCampaign: () => void;
   onEditCampaign: (campaign: ApplicationCampaign) => void;
   onDeleteCampaign: (id: string) => void;
+  onUpdateCampaignStatus: (id: string, status: CampaignStatus) => void;
   onDeleteApplication: (id: string, emailNormalized: string, campaignId: string) => void;
 }
 
 const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
-  campaigns, applications, onAddCampaign, onEditCampaign, onDeleteCampaign, onDeleteApplication,
+  campaigns, applications, onAddCampaign, onEditCampaign, onDeleteCampaign, onUpdateCampaignStatus, onDeleteApplication,
 }) => {
   const [filter, setFilter] = useState<"all" | CampaignStatus>("all");
   const [view, setView] = useState<"campaigns" | "submissions">("campaigns");
@@ -68,6 +78,23 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
   const [teamFilter, setTeamFilter] = useState<string>("all");
   const [confirmDeleteCampaign, setConfirmDeleteCampaign] = useState<ApplicationCampaign | null>(null);
   const [confirmDeleteApp, setConfirmDeleteApp] = useState<TeamApplication | null>(null);
+
+  // Load the selected campaign's questions so admins see readable labels for
+  // custom answers (falls back to the raw question id while loading).
+  const [questionsByCampaign, setQuestionsByCampaign] = useState<{ campaignId: string; questions: { id: string; question: string }[] } | null>(null);
+  useEffect(() => {
+    if (!selectedCampaign) return;
+    let active = true;
+    const unsub = subscribeToCampaignQuestions(selectedCampaign.id, (questions) => {
+      if (active) setQuestionsByCampaign({ campaignId: selectedCampaign.id, questions });
+    });
+    return () => { active = false; unsub(); };
+  }, [selectedCampaign]);
+
+  const questionMap = useMemo(() => {
+    if (!selectedCampaign || questionsByCampaign?.campaignId !== selectedCampaign.id) return null;
+    return new Map(questionsByCampaign.questions.map((q) => [q.id, q.question]));
+  }, [questionsByCampaign, selectedCampaign]);
 
   const filtered = filter === "all" ? campaigns : campaigns.filter((c) => c.status === filter);
   const counts = {
@@ -103,7 +130,7 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
 
   if (view === "submissions") {
     return (
-      <div>
+      <div key="submissions" className="animate-in fade-in slide-in-from-right-4 duration-300 ease-out">
         <div className="flex items-center gap-3 mb-6">
           <Button size="sm" icon={ArrowLeft} onClick={() => { setView("campaigns"); setSelectedCampaign(null); }}>Back to campaigns</Button>
           <div>
@@ -124,16 +151,16 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
           </div>
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Filter by team:</span>
-            <select
+            <SelectBase
               value={teamFilter}
               onChange={(e) => setTeamFilter(e.target.value)}
-              className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+              className="w-auto min-w-[140px]"
             >
               <option value="all">All teams</option>
               {Object.entries(TEAM_NAMES).map(([id, name]) => (
                 <option key={id} value={id}>{name}</option>
               ))}
-            </select>
+            </SelectBase>
           </div>
         </div>
 
@@ -201,9 +228,10 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                               <div className="space-y-2">
                                 {Object.entries(submission.customAnswers).map(([k, v]) => {
                                   const display = Array.isArray(v) ? v.join(", ") : v;
+                                  const label = questionMap?.get(k) || k;
                                   return (
                                     <div key={k}>
-                                      <span className="text-xs font-medium text-gray-600 dark:text-gray-400">{k}</span>
+                                      <span className="text-xs font-medium text-gray-600 dark:text-gray-400">{label}</span>
                                       <p className="text-sm text-gray-700 dark:text-gray-300 mt-0.5">{display || <span className="italic text-gray-400">No answer</span>}</p>
                                     </div>
                                   );
@@ -235,7 +263,7 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
 
   // Campaigns list view
   return (
-    <div>
+    <div key="campaigns" className="animate-in fade-in slide-in-from-right-4 duration-300 ease-out">
       <div className="flex justify-between items-center mb-6">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Application Campaigns</h1>
@@ -254,7 +282,7 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
             <button
               key={f}
               onClick={() => setFilter(f)}
-              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors duration-200 ${
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-all duration-200 ${
                 isActive ? "border-red-600 text-red-600 dark:text-red-400" : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
               }`}
             >
@@ -274,7 +302,6 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
           </div>
         ) : (
           filtered.map((c) => {
-            const status = STATUS_STYLES[c.status];
             const subCount = applications.filter((s) => s.campaignId === c.id).length;
             return (
               <Card key={c.id} className="bg-white dark:bg-gray-800">
@@ -283,7 +310,32 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                     <div className="flex-1 min-w-0">
                       <div className="flex flex-wrap items-center gap-2 mb-2">
                         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{c.title}</h2>
-                        <Tag variant={status.tagVariant} size="sm">{status.label}</Tag>
+                        <div
+                          role="group"
+                          aria-label={`Status for ${c.title}`}
+                          className="relative inline-flex items-center rounded-full border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-0.5"
+                        >
+                          <span
+                            aria-hidden
+                            className={`absolute inset-y-0.5 left-0.5 w-[calc((100%_-_4px)/3)] rounded-full shadow-sm transition-all duration-300 ease-out ${STATUS_TOGGLE_ACTIVE[c.status]}`}
+                            style={{ transform: `translateX(${STATUS_ORDER.indexOf(c.status) * 100}%)` }}
+                          />
+                          {STATUS_ORDER.map((s) => (
+                            <button
+                              key={s}
+                              type="button"
+                              onClick={() => onUpdateCampaignStatus(c.id, s)}
+                              aria-pressed={c.status === s}
+                              className={`relative z-10 flex-1 px-2.5 py-1 text-xs font-medium rounded-full transition-all duration-300 cursor-pointer ${
+                                c.status === s
+                                  ? "text-white"
+                                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                              }`}
+                            >
+                              {STATUS_STYLES[s].label}
+                            </button>
+                          ))}
+                        </div>
                       </div>
                       <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{c.subtitle} · {c.description}</p>
                       <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-400">

--- a/components/pages/admin/tabs/ApplicationsTab.tsx
+++ b/components/pages/admin/tabs/ApplicationsTab.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import {
+  Plus, Edit3, Trash2, Eye, ChevronDown, ChevronUp, Calendar,
+  Users, FileQuestion, Search, ArrowLeft,
+  Mail, ExternalLink,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import Tag from "@/components/ui/Tag";
+import { InputBase } from "@/components/ui/Form";
+import ConfirmModal from "@/components/ui/ConfirmModal";
+import {
+  ApplicationCampaign, TeamApplication, CampaignStatus,
+} from "@/types";
+
+const TEAM_NAMES: Record<string, string> = {
+  it: "IT",
+  development: "Development",
+  growth: "Growth",
+  partnerships_events: "Partnerships & Events",
+  research: "Research",
+};
+
+const STATUS_STYLES: Record<CampaignStatus, { label: string; tagVariant: "green" | "red" | "yellow" }> = {
+  open: { label: "Open", tagVariant: "green" },
+  closed: { label: "Closed", tagVariant: "red" },
+  draft: { label: "Draft", tagVariant: "yellow" },
+};
+
+const formatDate = (createdAt: TeamApplication["createdAt"]): string => {
+  if (!createdAt) return "—";
+  if (typeof createdAt === "string") {
+    const d = new Date(createdAt);
+    return Number.isNaN(d.getTime()) ? createdAt : d.toDateString();
+  }
+  return createdAt.toDate().toDateString();
+};
+
+/** Only allow http/https URLs to prevent javascript: XSS in href attributes. */
+function safeUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") return url;
+  } catch { /* invalid URL */ }
+  return undefined;
+}
+
+interface ApplicationsTabProps {
+  campaigns: ApplicationCampaign[];
+  applications: TeamApplication[];
+  onAddCampaign: () => void;
+  onEditCampaign: (campaign: ApplicationCampaign) => void;
+  onDeleteCampaign: (id: string) => void;
+  onDeleteApplication: (id: string, emailNormalized: string, campaignId: string) => void;
+}
+
+const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
+  campaigns, applications, onAddCampaign, onEditCampaign, onDeleteCampaign, onDeleteApplication,
+}) => {
+  const [filter, setFilter] = useState<"all" | CampaignStatus>("all");
+  const [view, setView] = useState<"campaigns" | "submissions">("campaigns");
+  const [selectedCampaign, setSelectedCampaign] = useState<ApplicationCampaign | null>(null);
+  const [expandApp, setExpandApp] = useState<Set<string>>(new Set());
+  const [search, setSearch] = useState("");
+  const [teamFilter, setTeamFilter] = useState<string>("all");
+  const [confirmDeleteCampaign, setConfirmDeleteCampaign] = useState<ApplicationCampaign | null>(null);
+  const [confirmDeleteApp, setConfirmDeleteApp] = useState<TeamApplication | null>(null);
+
+  const filtered = filter === "all" ? campaigns : campaigns.filter((c) => c.status === filter);
+  const counts = {
+    all: campaigns.length,
+    open: campaigns.filter((c) => c.status === "open").length,
+    closed: campaigns.filter((c) => c.status === "closed").length,
+    draft: campaigns.filter((c) => c.status === "draft").length,
+  };
+
+  // Submissions for selected campaign (or all)
+  const campaignSubs = useMemo(
+    () => applications.filter((s) => !selectedCampaign || s.campaignId === selectedCampaign.id),
+    [applications, selectedCampaign]
+  );
+  const filteredSubs = useMemo(() => {
+    return campaignSubs.filter((s) => {
+      if (search.trim()) {
+        const q = search.toLowerCase();
+        if (!s.name.toLowerCase().includes(q) && !s.email.toLowerCase().includes(q) && !(s.program || "").toLowerCase().includes(q)) return false;
+      }
+      if (teamFilter !== "all" && !(s.teamRanking || []).includes(teamFilter)) return false;
+      return true;
+    });
+  }, [campaignSubs, search, teamFilter]);
+
+  const toggleApp = (id: string) =>
+    setExpandApp((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  if (view === "submissions") {
+    return (
+      <div>
+        <div className="flex items-center gap-3 mb-6">
+          <Button size="sm" icon={ArrowLeft} onClick={() => { setView("campaigns"); setSelectedCampaign(null); }}>Back to campaigns</Button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              {selectedCampaign ? `Submissions: ${selectedCampaign.title}` : "All Submissions"}
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 flex items-center gap-3">
+              <span className="flex items-center gap-1"><Users className="h-3.5 w-3.5" /> {filteredSubs.length} of {campaignSubs.length}</span>
+              {selectedCampaign && <span>· Deadline {selectedCampaign.deadline}</span>}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 mb-6">
+          <div className="relative flex-1 max-w-md">
+            <Search className="h-4 w-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" />
+            <InputBase placeholder="Search by name, email, or programme..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Filter by team:</span>
+            <select
+              value={teamFilter}
+              onChange={(e) => setTeamFilter(e.target.value)}
+              className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+            >
+              <option value="all">All teams</option>
+              {Object.entries(TEAM_NAMES).map(([id, name]) => (
+                <option key={id} value={id}>{name}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid gap-3">
+          {filteredSubs.length === 0 ? (
+            <div className="text-center py-16 text-gray-500 dark:text-gray-400">No submissions match your filters.</div>
+          ) : (
+            filteredSubs.map((submission) => {
+              const isOpen = expandApp.has(submission.id);
+              return (
+                <Card key={submission.id} className="bg-white dark:bg-gray-800">
+                  <div className="p-5">
+                    <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
+                      <div className="flex-1 min-w-0">
+                        <button onClick={() => toggleApp(submission.id)} className="flex items-center gap-2 text-left group transition-all duration-300 ease-in-out cursor-pointer">
+                          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{submission.name}</h3>
+                          {isOpen
+                            ? <ChevronUp className="h-4 w-4 text-gray-400 group-hover:text-gray-600 transition-colors" />
+                            : <ChevronDown className="h-4 w-4 text-gray-400 group-hover:text-gray-600 transition-colors" />}
+                        </button>
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+                          <span className="flex items-center gap-1"><Mail className="h-3.5 w-3.5" /> {submission.email}</span>
+                          <span className="flex items-center gap-1"><Calendar className="h-3.5 w-3.5" /> {formatDate(submission.createdAt)}</span>
+                        </div>
+                      </div>
+                      <Button size="sm" variant="destructive" icon={Trash2} onClick={() => setConfirmDeleteApp(submission)}>
+                        <span className="sr-only">Delete</span>
+                      </Button>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5 mt-3">
+                      {submission.program && <Tag variant="red" size="sm">{submission.program}</Tag>}
+                      {submission.graduationYear && <Tag variant="green" size="sm">Class of {submission.graduationYear}</Tag>}
+                      {typeof submission.weeklyHours === "number" && <Tag variant="yellow" size="sm">{submission.weeklyHours} hr/wk</Tag>}
+                      {(submission.teamRanking || []).slice(0, 3).map((tid, idx) => {
+                        const name = TEAM_NAMES[tid] || tid;
+                        return <Tag key={tid} variant={idx === 0 ? "red" : "green"} size="sm">#{idx + 1} {name}</Tag>;
+                      })}
+                    </div>
+                    <div className={`grid overflow-hidden transition-all duration-500 ease-in-out ${isOpen ? "mt-4 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}>
+                      <div className="min-h-0">
+                        <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-3">
+                          {submission.linkedin && (
+                            <div className="text-sm">
+                              <span className="text-xs font-medium text-gray-500 uppercase mr-2">LinkedIn</span>
+                              <a href={safeUrl(submission.linkedin) || "#"} target="_blank" rel="noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1">
+                                {submission.linkedin} <ExternalLink className="h-3 w-3" />
+                              </a>
+                            </div>
+                          )}
+                          {submission.resume?.url && (
+                            <div className="text-sm">
+                              <span className="text-xs font-medium text-gray-500 uppercase mr-2">Resume</span>
+                              <a href={safeUrl(submission.resume.url) || "#"} target="_blank" rel="noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">View PDF</a>
+                            </div>
+                          )}
+                          {submission.motivation && (
+                            <div>
+                              <span className="block text-xs font-medium text-gray-500 uppercase mb-1">Motivation</span>
+                              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap border-l-2 border-gray-300 dark:border-gray-600 pl-3">{submission.motivation}</p>
+                            </div>
+                          )}
+                          {submission.customAnswers && Object.keys(submission.customAnswers).length > 0 && (
+                            <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+                              <span className="block text-xs font-medium text-gray-500 uppercase mb-2">Custom answers</span>
+                              <div className="space-y-2">
+                                {Object.entries(submission.customAnswers).map(([k, v]) => {
+                                  const display = Array.isArray(v) ? v.join(", ") : v;
+                                  return (
+                                    <div key={k}>
+                                      <span className="text-xs font-medium text-gray-600 dark:text-gray-400">{k}</span>
+                                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-0.5">{display || <span className="italic text-gray-400">No answer</span>}</p>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              );
+            })
+          )}
+        </div>
+
+        <ConfirmModal
+          open={!!confirmDeleteApp}
+          title="Delete submission?"
+          description={`This will permanently delete the submission from ${confirmDeleteApp?.name || "this applicant"}.`}
+          confirmText="Delete"
+          onClose={() => setConfirmDeleteApp(null)}
+          onConfirm={async () => { if (confirmDeleteApp) onDeleteApplication(confirmDeleteApp.id, confirmDeleteApp.emailNormalized || confirmDeleteApp.email.toLowerCase(), confirmDeleteApp.campaignId); setConfirmDeleteApp(null); }}
+        />
+      </div>
+    );
+  }
+
+  // Campaigns list view
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Application Campaigns</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Create and manage recruitment campaigns. Each campaign has its own form, deadline, and submissions.
+          </p>
+        </div>
+        <Button icon={Plus} onClick={onAddCampaign}>New campaign</Button>
+      </div>
+
+      <div className="flex items-center gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
+        {(["all", "open", "closed", "draft"] as const).map((f) => {
+          const isActive = filter === f;
+          const label = f === "all" ? "All" : STATUS_STYLES[f].label;
+          return (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors duration-200 ${
+                isActive ? "border-red-600 text-red-600 dark:text-red-400" : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+              }`}
+            >
+              {label}
+              <span className={`ml-2 inline-flex items-center justify-center text-xs rounded-full px-1.5 ${
+                isActive ? "bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400" : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+              }`}>{counts[f]}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-4">
+        {filtered.length === 0 ? (
+          <div className="text-center py-16 text-gray-500 dark:text-gray-400">
+            No campaigns with status &ldquo;{filter !== "all" ? STATUS_STYLES[filter].label : "all"}&rdquo;.
+          </div>
+        ) : (
+          filtered.map((c) => {
+            const status = STATUS_STYLES[c.status];
+            const subCount = applications.filter((s) => s.campaignId === c.id).length;
+            return (
+              <Card key={c.id} className="bg-white dark:bg-gray-800">
+                <div className="p-5">
+                  <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2 mb-2">
+                        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{c.title}</h2>
+                        <Tag variant={status.tagVariant} size="sm">{status.label}</Tag>
+                      </div>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{c.subtitle} · {c.description}</p>
+                      <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+                        <span className="flex items-center gap-1"><Calendar className="h-3.5 w-3.5" /> Deadline {c.deadline}</span>
+                        <span className="flex items-center gap-1"><Users className="h-3.5 w-3.5" /> {subCount} submission{subCount !== 1 ? "s" : ""}</span>
+                        <span className="flex items-center gap-1"><FileQuestion className="h-3.5 w-3.5" /> {c.teams.length} team{c.teams.length !== 1 ? "s" : ""}</span>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 shrink-0">
+                      {subCount > 0 && (
+                        <Button size="sm" variant="outline" icon={Eye} onClick={() => { setSelectedCampaign(c); setView("submissions"); }}>View submissions</Button>
+                      )}
+                      <Button size="sm" variant="outline" icon={Edit3} onClick={() => onEditCampaign(c)}>Edit</Button>
+                      <Button size="sm" variant="destructive" icon={Trash2} onClick={() => setConfirmDeleteCampaign(c)}>
+                        <span className="sr-only">Delete campaign</span>
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            );
+          })
+        )}
+      </div>
+
+      <ConfirmModal
+        open={!!confirmDeleteCampaign}
+        title="Delete campaign?"
+        description={`This will permanently delete "${confirmDeleteCampaign?.title}" and all its custom questions. Submissions will remain in Firestore.`}
+        confirmText="Delete"
+        onClose={() => setConfirmDeleteCampaign(null)}
+        onConfirm={async () => { if (confirmDeleteCampaign) onDeleteCampaign(confirmDeleteCampaign.id); setConfirmDeleteCampaign(null); }}
+      />
+    </div>
+  );
+};
+
+export default ApplicationsTab;

--- a/components/pages/apply/sampleData.ts
+++ b/components/pages/apply/sampleData.ts
@@ -1,0 +1,414 @@
+// Shared mock data for design examples (no backend).
+// This data shape previews what admin-configurable "application campaigns"
+// will look like once Phase 3 backend is built.
+
+// ---------------------------------------------------------------------------
+// Types — board application (legacy concept examples)
+// ---------------------------------------------------------------------------
+
+export type CustomQuestionType = 'text' | 'textarea' | 'select' | 'radio' | 'checkbox';
+
+export interface SampleCustomQuestion {
+  id: string;
+  question: string;
+  type: CustomQuestionType;
+  options?: string[];
+  required: boolean;
+}
+
+export interface SamplePosition {
+  id: string;
+  title: string;
+  short: string;
+  description: string;
+  tags: string[];
+  deadline: string;
+  customQuestions: SampleCustomQuestion[];
+}
+
+export const COVER_LETTER_MAX_CHARS = 3500;
+
+export const sampleCampaign = {
+  title: 'Board Recruitment',
+  subtitle: 'Spring General Assembly 2026',
+  description: 'Apply now for our board positions ahead of the Spring General Assembly 2026. For specific clarifications, drop us a mail at contact@uuais.com.',
+  deadline: '2026-05-10',
+};
+
+// ---------------------------------------------------------------------------
+// Types — team application (combined concept)
+// ---------------------------------------------------------------------------
+
+export interface TeamInfo {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface AreaOfInterest {
+  id: string;
+  label: string;
+}
+
+export const teamCampaign = {
+  title: 'Join Our Teams',
+  subtitle: 'UU AI Society — Spring 2026',
+  description:
+    'We are looking for passionate students to join our teams. Whether you are a developer, a creative mind, an organiser, or a researcher — there is a place for you here. Explore our teams below and apply for the ones that excite you.',
+  deadline: '2026-05-10',
+};
+
+export const SAMPLE_TEAMS: TeamInfo[] = [
+  {
+    id: 'it',
+    name: 'IT',
+    description:
+      'Maintain and develop the society\'s website, technological infrastructure, and internal tools. You will work with modern web technologies and keep our digital presence running smoothly.',
+  },
+  {
+    id: 'development',
+    name: 'Development',
+    description:
+      'Build tech-based projects and develop ideas with a team of driven minds. From hackathon prototypes to production tools — this team turns ideas into working software.',
+  },
+  {
+    id: 'growth',
+    name: 'Growth',
+    description:
+      'Organise workshops, seminars, and community events. Manage marketing through social media and other outlets. This team drives our community engagement and visibility.',
+  },
+  {
+    id: 'partnerships_events',
+    name: 'Partnerships & Events',
+    description:
+      'Plan and coordinate events, foster communication with partner organisations, and build relationships with companies and sponsors that support our society.',
+  },
+  {
+    id: 'research',
+    name: 'Research',
+    description:
+      'Explore cutting-edge AI research and bring academic perspectives to the society. Write blog posts, host reading groups, and connect the society with the latest developments in AI.',
+  },
+];
+
+export const UU_PROGRAMMES: string[] = [
+  'Computer Science (BSc)',
+  'Information Technology (BSc)',
+  'Mathematics (BSc)',
+  'Physics (BSc)',
+  'Data Science (MSc)',
+  'Computational Science (MSc)',
+  'Engineering Physics (MSc)',
+  'Industrial Engineering and Management (MSc)',
+  'Molecular Biotechnology (MSc)',
+  'Sociotechnical Systems Engineering (MSc)',
+  'Biomedicine (BSc)',
+  'Sustainable Development (MSc)',
+  'Economics (BSc)',
+  'Business and Economics (BSc)',
+  'Law (LLM)',
+  'Psychology (BSc)',
+  'Political Science (BSc)',
+  'Sociology (BSc)',
+  'Media and Communication Studies (BSc)',
+  'Other',
+];
+
+export const AREAS_OF_INTEREST: AreaOfInterest[] = [
+  { id: 'robotics', label: 'Robotics' },
+  { id: 'data_science', label: 'Data Science' },
+  { id: 'nlp', label: 'Natural Language Processing' },
+  { id: 'computer_vision', label: 'Computer Vision' },
+  { id: 'reinforcement_learning', label: 'Reinforcement Learning' },
+  { id: 'ai_ethics', label: 'AI Ethics & Fairness' },
+  { id: 'generative_ai', label: 'Generative AI' },
+  { id: 'ml_engineering', label: 'Machine Learning Engineering' },
+];
+
+// Mock profile — simulates a logged-in user with profile data to prefill.
+// In Phase 3, this will come from auth.onAuthStateChanged + getUserProfile().
+export const mockProfile = {
+  displayName: 'Alex Doe',
+  name: 'Alexander Doe',
+  email: 'alex.doe.1234@student.uu.se',
+  gender: 'other',
+  university: 'Uppsala',
+  program: 'Data Science (MSc)',
+  expectedGraduationYear: 2027,
+  linkedin: 'https://linkedin.com/in/alexdoe',
+};
+
+export const MOTIVATION_MAX_CHARS = 1500;
+
+export const samplePositions: SamplePosition[] = [
+  {
+    id: 'chairman',
+    title: 'Chairman of the Board',
+    short: 'Deadline: May 10, 2026',
+    deadline: '2026-05-10',
+    tags: ['Leadership', 'External'],
+    description:
+      'Responsible for overall leadership, meeting facilitation, mentorship, and representing UU AI Society to internal and external stakeholders. The Chairman sets the strategic direction and ensures the society runs smoothly throughout the academic year.',
+    customQuestions: [],
+  },
+  {
+    id: 'vice-chairman',
+    title: 'Vice Chairman of the Board',
+    short: 'Deadline: May 10, 2026',
+    deadline: '2026-05-10',
+    tags: ['Leadership', 'Coordination'],
+    description:
+      'Second-highest management role, for technical coordination, decision-making and mentorship of the board members and members in UU AI Society.',
+    customQuestions: [],
+  },
+  {
+    id: 'head-of-internal-it',
+    title: 'Head of Internal IT',
+    short: 'Deadline: May 10, 2026',
+    deadline: '2026-05-10',
+    tags: ['IT', 'Infrastructure'],
+    description:
+      'Management of IT services of UU AI Society, such as the website and technological assets.',
+    customQuestions: [
+      {
+        id: 'it-experience',
+        question: 'Describe your experience with web development and server infrastructure.',
+        type: 'textarea',
+        required: true,
+      },
+      {
+        id: 'it-stack',
+        question: 'Which technologies are you most comfortable with?',
+        type: 'checkbox',
+        options: ['React/Next.js', 'Firebase', 'Node.js', 'Python', 'Docker', 'Other'],
+        required: false,
+      },
+    ],
+  },
+  {
+    id: 'head-of-dev',
+    title: 'Head of Development',
+    short: 'Deadline: May 10, 2026',
+    deadline: '2026-05-10',
+    tags: ['Dev', 'Projects'],
+    description:
+      'Managing development, and a team of driven minds to develop ideas for tech-based projects built at UU AI Society.',
+    customQuestions: [
+      {
+        id: 'dev-projects',
+        question: 'What project idea would you bring to the society in your first semester?',
+        type: 'textarea',
+        required: true,
+      },
+      {
+        id: 'dev-team-size',
+        question: 'How many people have you led on a project team before?',
+        type: 'select',
+        options: ['1-3', '4-6', '7-10', '10+'],
+        required: false,
+      },
+    ],
+  },
+  {
+    id: 'head-of-partnerships',
+    title: 'Head of Partnerships & Events',
+    short: 'Deadline: May 10, 2026',
+    deadline: '2026-05-10',
+    tags: ['Events', 'Outreach'],
+    description:
+      'As Head of Partnerships & Events, you are in charge of planning and coordinating events, along with fostering communication and collaborating with partner organizations.',
+    customQuestions: [
+      {
+        id: 'events-experience',
+        question: 'What is the largest event you have organized or co-organized?',
+        type: 'radio',
+        options: ['Under 50 attendees', '50-200 attendees', '200+ attendees', 'No event experience'],
+        required: true,
+      },
+    ],
+  },
+  {
+    id: 'head-of-growth',
+    title: 'Head of Growth',
+    short: 'Deadline: May 10, 2026',
+    deadline: '2026-05-10',
+    tags: ['Marketing', 'Community'],
+    description:
+      'Organizing workshops, seminars, talks and community events by UU AI Society. You shall also manage marketing through social media and other outlets, along with communication with participants and visitors.',
+    customQuestions: [],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Admin mock data — campaigns + submissions
+// ---------------------------------------------------------------------------
+
+export type CampaignStatus = 'open' | 'closed' | 'draft';
+
+export interface AdminCampaign {
+  id: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  deadline: string;
+  status: CampaignStatus;
+  teamIds: string[];
+  customQuestionCount: number;
+  submissionCount: number;
+  createdAt: string;
+}
+
+export interface AdminSubmission {
+  id: string;
+  campaignId: string;
+  name: string;
+  email: string;
+  program: string;
+  graduationYear: string;
+  linkedin: string;
+  interests: string[];
+  teamRanking: string[];
+  weeklyHours: number;
+  motivation: string;
+  customAnswers: Record<string, string>;
+  submittedAt: string;
+}
+
+export interface AdminCampaignQuestion {
+  id: string;
+  campaignId: string;
+  question: string;
+  type: CustomQuestionType;
+  options?: string[];
+  required: boolean;
+  order: number;
+}
+
+export const adminCampaigns: AdminCampaign[] = [
+  {
+    id: 'spring2026',
+    title: 'Spring 2026 Recruitment',
+    subtitle: 'UU AI Society — Spring 2026',
+    description: 'Main yearly recruitment drive for all society teams.',
+    deadline: '2026-05-10',
+    status: 'open',
+    teamIds: ['it', 'development', 'growth', 'partnerships_events', 'research'],
+    customQuestionCount: 2,
+    submissionCount: 47,
+    createdAt: '2026-02-01',
+  },
+  {
+    id: 'autumn2025',
+    title: 'Autumn 2025 Recruitment',
+    subtitle: 'UU AI Society — Autumn 2025',
+    description: 'Autumn recruitment drive, now closed.',
+    deadline: '2025-10-15',
+    status: 'closed',
+    teamIds: ['it', 'development', 'growth'],
+    customQuestionCount: 0,
+    submissionCount: 23,
+    createdAt: '2025-08-15',
+  },
+  {
+    id: 'research-summer2026',
+    title: 'Research Team Summer Intake',
+    subtitle: 'Specialised intake — Research team only',
+    description: 'Targeted intake for students interested in producing AI research content.',
+    deadline: '2026-06-01',
+    status: 'draft',
+    teamIds: ['research'],
+    customQuestionCount: 4,
+    submissionCount: 0,
+    createdAt: '2026-04-20',
+  },
+];
+
+export const adminSubmissions: AdminSubmission[] = [
+  {
+    id: 's1',
+    campaignId: 'spring2026',
+    name: 'Alex Doe',
+    email: 'alex.doe.1234@student.uu.se',
+    program: 'Data Science (MSc)',
+    graduationYear: '2027',
+    linkedin: 'https://linkedin.com/in/alexdoe',
+    interests: ['robotics', 'data_science', 'generative_ai'],
+    teamRanking: ['development', 'it', 'research'],
+    weeklyHours: 8,
+    motivation:
+      'Excited to contribute to the AI community at Uppsala and grow alongside passionate peers. My background in data science and my interest in generative AI tools would let me hit the ground running.',
+    customAnswers: {
+      'portfolio': 'https://github.com/alexdoe',
+      'project-idea': 'Build an AI-powered course recommendation tool for UU students.',
+    },
+    submittedAt: '2026-04-12',
+  },
+  {
+    id: 's2',
+    campaignId: 'spring2026',
+    name: 'Maria Lind',
+    email: 'maria.lind.5678@student.uu.se',
+    program: 'Computer Science (BSc)',
+    graduationYear: '2028',
+    linkedin: 'https://linkedin.com/in/marialind',
+    interests: ['nlp', 'ai_ethics'],
+    teamRanking: ['growth', 'partnerships_events'],
+    weeklyHours: 5,
+    motivation: 'I want to help organise events that bring AI researchers and students together.',
+    customAnswers: { 'portfolio': '', 'project-idea': '' },
+    submittedAt: '2026-04-14',
+  },
+  {
+    id: 's3',
+    campaignId: 'spring2026',
+    name: 'Jonas Berg',
+    email: 'jonas.berg.9012@student.uu.se',
+    program: 'Engineering Physics (MSc)',
+    graduationYear: '2026',
+    linkedin: 'https://linkedin.com/in/jonasberg',
+    interests: ['reinforcement_learning', 'ml_engineering'],
+    teamRanking: ['research', 'development', 'it', 'partnerships_events'],
+    weeklyHours: 12,
+    motivation:
+      'As an engineering physics student with an interest in RL, I want to apply my skills to real-world AI projects and connect with researchers in the field.',
+    customAnswers: {
+      'portfolio': 'https://github.com/jonasb',
+      'project-idea': 'Reinforcement learning sandbox for optimising campus bus routes.',
+    },
+    submittedAt: '2026-04-15',
+  },
+];
+
+export const adminCampaignQuestions: AdminCampaignQuestion[] = [
+  {
+    id: 'portfolio',
+    campaignId: 'spring2026',
+    question: 'Portfolio URL (GitHub, personal website, etc.)',
+    type: 'text',
+    required: false,
+    order: 1,
+  },
+  {
+    id: 'project-idea',
+    campaignId: 'spring2026',
+    question: 'What project idea would you bring to the society in your first semester?',
+    type: 'textarea',
+    required: true,
+    order: 2,
+  },
+];
+
+export const STANDARD_FIELDS_CATALOG = [
+  { id: 'name', label: 'Full name', defaultRequired: true },
+  { id: 'email', label: 'Email', defaultRequired: true },
+  { id: 'gender', label: 'Gender', defaultRequired: false },
+  { id: 'university', label: 'University', defaultRequired: true },
+  { id: 'program', label: 'Programme', defaultRequired: true },
+  { id: 'graduationYear', label: 'Expected graduation year', defaultRequired: false },
+  { id: 'linkedin', label: 'LinkedIn URL', defaultRequired: true },
+  { id: 'resume', label: 'Resume / CV upload', defaultRequired: false },
+  { id: 'interests', label: 'Areas of interest', defaultRequired: false },
+  { id: 'teamRanking', label: 'Team preference ranking', defaultRequired: true },
+  { id: 'weeklyHours', label: 'Weekly availability', defaultRequired: true },
+  { id: 'motivation', label: 'Personal motivation', defaultRequired: true },
+] as const;

--- a/components/ui/LinkedInUrlInput.tsx
+++ b/components/ui/LinkedInUrlInput.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef } from "react";
 import { InputBase } from "./Form";
 
-const LINKEDIN_PREFIX = "https://www.linkedin.com/in/";
+export const LINKEDIN_PREFIX = "https://www.linkedin.com/in/";
 const LINKEDIN_REGEX = /^(https?:\/\/)?(www\.)?linkedin\.com\/in\//i;
 
 export function LinkedInUrlInput({

--- a/components/ui/LinkedInUrlInput.tsx
+++ b/components/ui/LinkedInUrlInput.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { InputBase } from "./Form";
+
+const LINKEDIN_PREFIX = "https://www.linkedin.com/in/";
+const LINKEDIN_REGEX = /^(https?:\/\/)?(www\.)?linkedin\.com\/in\//i;
+
+export function LinkedInUrlInput({
+  value,
+  onChange,
+  ...props
+}: Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> & {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  const seeded = useRef(false);
+
+  useEffect(() => {
+    if (!seeded.current && !value) {
+      seeded.current = true;
+      onChange(LINKEDIN_PREFIX);
+    }
+  }, [value, onChange]);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    let v = e.target.value;
+    if (v.startsWith(LINKEDIN_PREFIX + LINKEDIN_PREFIX)) {
+      v = v.slice(LINKEDIN_PREFIX.length);
+    } else if (/^https?:\/\/https?:\/\//i.test(v)) {
+      v = v.replace(/^https?:\/\//i, "");
+    }
+    onChange(v);
+  }
+
+  function normalize(v: string) {
+    if (!v || v === LINKEDIN_PREFIX) return;
+    if (LINKEDIN_REGEX.test(v)) return;
+    const cleaned = v.replace(/^https?:\/\//i, "").replace(/^www\./i, "");
+    onChange(LINKEDIN_PREFIX + cleaned);
+  }
+
+  return (
+    <InputBase
+      ref={ref}
+      maxLength={200}
+      placeholder={LINKEDIN_PREFIX + "username"}
+      value={value}
+      onChange={handleChange}
+      onBlur={() => normalize(value)}
+      {...props}
+    />
+  );
+}

--- a/components/ui/MultiStepWizard.tsx
+++ b/components/ui/MultiStepWizard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React from "react";
+import { ArrowRight, ArrowLeft, Check } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+export interface WizardStep {
+  key: string;
+  title: string;
+}
+
+export interface MultiStepWizardProps {
+  steps: WizardStep[];
+  currentStep: number;
+  onNext: () => void;
+  onBack: () => void;
+  onSubmit: () => void;
+  canNext?: boolean;
+  canBack?: boolean;
+  submitLabel?: string;
+  submitDisabled?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Generic, reusable multi-step wizard shell.
+ *
+ * Renders a progress bar, the current step content (children), and
+ * navigation buttons. The parent owns `currentStep` state and is
+ * responsible for rendering the right content per step.
+ */
+const MultiStepWizard: React.FC<MultiStepWizardProps> = ({
+  steps,
+  currentStep,
+  onNext,
+  onBack,
+  onSubmit,
+  canNext = true,
+  canBack = true,
+  submitLabel = "Submit",
+  submitDisabled = false,
+  children,
+}) => {
+  const isLast = currentStep === steps.length - 1;
+  const isFirst = currentStep === 0;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      {/* Progress Bar */}
+      <div className="mb-10">
+        <div className="flex items-center justify-between">
+          {steps.map((step, i) => {
+            const isLast = i === steps.length - 1;
+            const isFirst = i === 0;
+            // Left connector fills when this step is reached (i.e., i <= currentStep)
+            const leftFilled = i <= currentStep;
+            // Right connector fills when advancing to next step (i.e., i < currentStep)
+            const rightFilled = i < currentStep;
+            return (
+              <div key={step.key} className="flex flex-col items-center flex-1">
+                {/* Row: [left-line | circle | right-line] — keeps the circle centered above the label */}
+                <div className="flex items-center w-full">
+                  {/* Left line: takes flex-1; invisible spacer on step 0 so circle stays centered */}
+                  <div
+                    className={`h-0.5 flex-1 transition-colors duration-500 ${
+                      isFirst ? "opacity-0" : leftFilled ? "bg-red-600 dark:bg-red-500" : "bg-gray-200 dark:bg-gray-700"
+                    }`}
+                  />
+                  <div
+                    className={`w-10 h-10 rounded-full flex items-center justify-center font-semibold text-sm shrink-0 transition-all duration-300 ${
+                      i < currentStep
+                        ? "bg-green-600 text-white"
+                        : i === currentStep
+                          ? "bg-red-600 dark:bg-red-500 text-white ring-4 ring-red-600/20 dark:ring-red-500/30"
+                          : "bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-600 border border-gray-200 dark:border-gray-700"
+                    }`}
+                  >
+                    {i < currentStep ? <Check className="h-5 w-5" /> : i + 1}
+                  </div>
+                  {/* Right line: takes flex-1; invisible spacer on the last step */}
+                  <div
+                    className={`h-0.5 flex-1 transition-colors duration-500 ${
+                      isLast ? "opacity-0" : rightFilled ? "bg-red-600 dark:bg-red-500" : "bg-gray-200 dark:bg-gray-700"
+                    }`}
+                  />
+                </div>
+                <span
+                  className={`text-xs mt-2 font-medium text-center transition-colors duration-300 ${
+                    i === currentStep
+                      ? "text-red-600 dark:text-red-400"
+                      : i < currentStep
+                        ? "text-gray-700 dark:text-gray-300"
+                        : "text-gray-400 dark:text-gray-500"
+                  }`}
+                >
+                  {step.title}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Step Content */}
+      <div key={currentStep} className="animate-in fade-in slide-in-from-right-4 duration-300">
+        {children}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between items-center mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onBack}
+          disabled={!canBack || isFirst}
+          className={`${
+            isFirst ? "opacity-0!" : ""
+          }`}
+        >
+          {!isFirst && <ArrowLeft className="h-5 w-5 mr-1" />}
+          {!isFirst ? "Back" : ""}
+        </Button>
+        {isLast ? (
+          <Button
+            type="button"
+            variant="cta"
+            size="lg"
+            onClick={onSubmit}
+            disabled={submitDisabled}
+          >
+            {submitLabel} <Check className="ml-1 h-5 w-5" />
+          </Button>
+        ) : (
+          <Button type="button" onClick={onNext} disabled={!canNext}>
+            Continue <ArrowRight className="ml-1 h-5 w-5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MultiStepWizard;

--- a/components/ui/PDFDropzone.tsx
+++ b/components/ui/PDFDropzone.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { useState, useRef } from "react";
+import { FileText, Upload } from "lucide-react";
+
+const MAX_BYTES = 3 * 1024 * 1024;
+
+interface PDFDropzoneProps {
+  file: File | null;
+  onChange: (f: File | null) => void;
+  onError?: (msg: string) => void;
+}
+
+export default function PDFDropzone({ file, onChange, onError }: PDFDropzoneProps) {
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const accept = (f: File) => {
+    if (f.type !== "application/pdf") {
+      onError?.("Resume must be a PDF.");
+      return;
+    }
+    if (f.size > MAX_BYTES) {
+      onError?.("Resume must be at most 3MB.");
+      return;
+    }
+    onChange(f);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragging(false);
+    const f = e.dataTransfer.files?.[0];
+    if (f) accept(f);
+  };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) accept(f);
+  };
+
+  if (file) {
+    return (
+      <div className="flex items-center gap-3 p-3 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+        <FileText className="h-5 w-5 text-red-600 dark:text-red-400 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{file.name}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {(file.size / 1024 / 1024).toFixed(2)} MB · PDF
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className="text-sm text-red-600 dark:text-red-400 hover:underline shrink-0"
+        >
+          Remove
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+      onDragLeave={() => setDragging(false)}
+      onClick={() => inputRef.current?.click()}
+      className={`w-full border-2 border-dashed rounded-md p-5 flex items-center justify-center gap-3 cursor-pointer transition-colors duration-200 ${
+        dragging
+          ? "border-red-500 bg-red-50/50 dark:bg-red-950/20"
+          : "border-gray-300 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-600"
+      }`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf"
+        className="hidden"
+        onChange={handleChange}
+      />
+      <Upload className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+      <div className="text-sm text-gray-600 dark:text-gray-300">
+        Drag & drop your resume here, or{" "}
+        <span className="text-blue-600 dark:text-blue-400 underline">browse</span>
+        <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">PDF, max 3MB</span>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/TeamRanker.tsx
+++ b/components/ui/TeamRanker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { ArrowUp, ArrowDown, GripVertical, Server, Code2, Megaphone, CalendarDays, FlaskConical, Rocket } from "lucide-react";
+import { ArrowUp, ArrowDown, GripVertical, Server, Code2, Megaphone, CalendarDays, FlaskConical, Rocket, X } from "lucide-react";
 
 export interface TeamRankEntry {
   id: string;
@@ -75,9 +75,14 @@ const TeamRanker: React.FC<TeamRankerProps> = ({
   };
 
   // Reorder within preferences
-  const handlePrefDragOver = (e: React.DragEvent, idx: number) => { e.preventDefault(); setDragOverIdx(idx); };
+  const handlePrefDragOver = (e: React.DragEvent, idx: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOverIdx(idx);
+  };
   const handlePrefDrop = (e: React.DragEvent, idx: number) => {
     e.preventDefault();
+    e.stopPropagation(); // don't let the container's drop handler also fire
     if (draggedId && available.includes(draggedId)) {
       // Dropped from Available zone into Preferences list at a specific position
       const newEntry = { id: draggedId, name: teamName(draggedId) };
@@ -112,7 +117,7 @@ const TeamRanker: React.FC<TeamRankerProps> = ({
     setDragOverIdx(null);
   };
 
-  const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); setDropZoneOver(true); };
+  const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; setDropZoneOver(true); };
   const handleDragLeave = () => setDropZoneOver(false);
 
   return (
@@ -121,8 +126,7 @@ const TeamRanker: React.FC<TeamRankerProps> = ({
         Draggable Team Selection
       </h3>
       <p className="text-xs text-gray-500 dark:text-gray-400 mb-5">
-        Drag teams between the two zones, or click to quickly add/remove. Order within &ldquo;Your Preferences&rdquo;
-        determines your ranking — #1 = first choice.
+        Click teams to add or remove them, then drag to put them in order — #1 is your first choice.
       </p>
 
       {/* ── Your Preferences zone ── */}
@@ -160,7 +164,7 @@ const TeamRanker: React.FC<TeamRankerProps> = ({
                 <div
                   key={entry.id}
                   draggable
-                  onDragStart={() => setDraggedId(entry.id)}
+                  onDragStart={(e) => { e.dataTransfer.setData("text/plain", entry.id); e.dataTransfer.effectAllowed = "move"; setDraggedId(entry.id); }}
                   onDragOver={(e) => handlePrefDragOver(e, idx)}
                   onDrop={(e) => handlePrefDrop(e, idx)}
                   onDragEnd={() => { setDraggedId(null); setDragOverIdx(null); }}
@@ -191,15 +195,14 @@ const TeamRanker: React.FC<TeamRankerProps> = ({
                     <span className="flex-1 text-sm font-medium text-gray-900 dark:text-white">{entry.name}</span>
                   )}
                   <div className="shrink-0 flex items-center gap-1">
-                    <button type="button" onClick={() => move(idx, idx - 1)} disabled={idx === 0} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 transition-colors" title="Move up">
+                    <button type="button" onClick={() => move(idx, idx - 1)} disabled={idx === 0} className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 transition-colors" title="Move up" aria-label={`Move ${entry.name} up`}>
                       <ArrowUp className="h-4 w-4" />
                     </button>
-                    <button type="button" onClick={() => move(idx, idx + 1)} disabled={idx === ranking.length - 1} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 transition-colors" title="Move down">
+                    <button type="button" onClick={() => move(idx, idx + 1)} disabled={idx === ranking.length - 1} className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 transition-colors" title="Move down" aria-label={`Move ${entry.name} down`}>
                       <ArrowDown className="h-4 w-4" />
                     </button>
-                    <button type="button" onClick={() => removeTeam(entry.id)} className="p-1 text-red-500 hover:text-red-600 transition-colors" title="Remove from preferences">
-                      <span className="sr-only">Remove {entry.name}</span>
-                      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                    <button type="button" onClick={() => removeTeam(entry.id)} className="p-2 text-red-500 hover:text-red-600 transition-colors" title="Remove from preferences" aria-label={`Remove ${entry.name}`}>
+                      <X className="h-4 w-4" />
                     </button>
                   </div>
                 </div>
@@ -243,7 +246,7 @@ const TeamRanker: React.FC<TeamRankerProps> = ({
                     key={id}
                     type="button"
                     draggable
-                    onDragStart={() => setDraggedId(id)}
+                    onDragStart={(e) => { e.dataTransfer.setData("text/plain", id); e.dataTransfer.effectAllowed = "move"; setDraggedId(id); }}
                     onClick={() => addTeam(id)}
                     title="Drag to Your Preferences, or click to add"
                     className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm font-medium text-gray-700 dark:text-gray-300 hover:border-red-300 dark:hover:border-red-700 hover:bg-red-50 dark:hover:bg-red-950/20 transition-all duration-200 cursor-grab active:cursor-grabbing"

--- a/components/ui/TeamRanker.tsx
+++ b/components/ui/TeamRanker.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import React, { useState } from "react";
+import { ArrowUp, ArrowDown, GripVertical, Server, Code2, Megaphone, CalendarDays, FlaskConical, Rocket } from "lucide-react";
+
+export interface TeamRankEntry {
+  id: string;
+  name: string;
+  custom?: boolean;
+}
+
+export interface TeamRankerProps {
+  ranking: TeamRankEntry[];
+  onChange: (ranking: TeamRankEntry[]) => void;
+  availableTeamIds: string[];
+  /** Maps a team id to a display name (used for the available list). */
+  teamName: (id: string) => string;
+  /** Optional icon map for team pills. */
+  iconMap?: Record<string, React.ComponentType<{ className?: string }>>;
+  customTeam: string;
+  onCustomTeamChange: (val: string) => void;
+}
+
+const DEFAULT_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  it: Server,
+  development: Code2,
+  growth: Megaphone,
+  partnerships_events: CalendarDays,
+  research: FlaskConical,
+  other: Rocket,
+};
+
+const TeamRanker: React.FC<TeamRankerProps> = ({
+  ranking,
+  onChange,
+  availableTeamIds,
+  teamName,
+  iconMap = DEFAULT_ICONS,
+  customTeam,
+  onCustomTeamChange,
+}) => {
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [dropZoneOver, setDropZoneOver] = useState(false);
+  const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
+
+  const IconFor = (id: string) => iconMap[id] || Rocket;
+
+  const available = availableTeamIds.filter((id) => !ranking.find((r) => r.id === id));
+  const otherEntry = ranking.find((r) => r.custom);
+
+  const addTeam = (id: string) => {
+    onChange([...ranking, { id, name: teamName(id) }]);
+  };
+  const removeTeam = (id: string) => {
+    onChange(ranking.filter((r) => r.id !== id));
+  };
+  const addOther = () => {
+    onChange([...ranking, { id: "other", name: "Other", custom: true }]);
+    onCustomTeamChange("");
+  };
+  const move = (from: number, to: number) => {
+    if (from === to || from < 0 || to < 0 || from >= ranking.length || to >= ranking.length) return;
+    const next = [...ranking];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    onChange(next);
+  };
+  const appendToPreferences = (id: string) => {
+    if (id === "other") { addOther(); return; }
+    if (available.includes(id)) addTeam(id);
+  };
+  const moveFromPreferencesToAvailable = (id: string) => {
+    if (id === "other") { removeTeam(id); onCustomTeamChange(""); return; }
+    removeTeam(id);
+  };
+
+  // Reorder within preferences
+  const handlePrefDragOver = (e: React.DragEvent, idx: number) => { e.preventDefault(); setDragOverIdx(idx); };
+  const handlePrefDrop = (e: React.DragEvent, idx: number) => {
+    e.preventDefault();
+    if (draggedId && available.includes(draggedId)) {
+      // Dropped from Available zone into Preferences list at a specific position
+      const newEntry = { id: draggedId, name: teamName(draggedId) };
+      const next = [...ranking];
+      next.splice(idx, 0, newEntry);
+      onChange(next);
+    } else {
+      const fromIdx = ranking.findIndex((r) => r.id === draggedId);
+      if (fromIdx >= 0) move(fromIdx, idx);
+    }
+    setDraggedId(null); setDragOverIdx(null);
+  };
+
+  // Drop into the available zone (removes from preferences)
+  const handleAvailableDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDropZoneOver(false);
+    if (draggedId && !available.includes(draggedId)) {
+      moveFromPreferencesToAvailable(draggedId);
+    }
+    setDraggedId(null);
+  };
+
+  // Drop into the preferences zone (outside any specific item — appends to end)
+  const handlePreferencesDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDropZoneOver(false);
+    if (draggedId && available.includes(draggedId)) {
+      appendToPreferences(draggedId);
+    }
+    setDraggedId(null);
+    setDragOverIdx(null);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); setDropZoneOver(true); };
+  const handleDragLeave = () => setDropZoneOver(false);
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-2">
+        Draggable Team Selection
+      </h3>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-5">
+        Drag teams between the two zones, or click to quickly add/remove. Order within &ldquo;Your Preferences&rdquo;
+        determines your ranking — #1 = first choice.
+      </p>
+
+      {/* ── Your Preferences zone ── */}
+      <div
+        className={`rounded-lg border-2 border-dashed p-4 transition-colors duration-200 ${
+          dropZoneOver ? "border-red-500 bg-red-50/50 dark:bg-red-950/20" : "border-gray-300 dark:border-gray-700"
+        }`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handlePreferencesDrop}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
+            Your Preferences {ranking.length > 0 && <span className="text-red-600 dark:text-red-400">({ranking.length})</span>}
+          </span>
+          {ranking.length > 0 && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">#1 = first choice</span>
+          )}
+        </div>
+
+        {ranking.length === 0 ? (
+          <div className="text-center py-6">
+            <GripVertical className="h-5 w-5 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Drag teams from &ldquo;Available&rdquo; below, or click them to add.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {ranking.map((entry, idx) => {
+              const Icon = IconFor(entry.id);
+              const isDragging = draggedId === entry.id;
+              const isDragOver = dragOverIdx === idx && draggedId !== null && draggedId !== entry.id;
+              return (
+                <div
+                  key={entry.id}
+                  draggable
+                  onDragStart={() => setDraggedId(entry.id)}
+                  onDragOver={(e) => handlePrefDragOver(e, idx)}
+                  onDrop={(e) => handlePrefDrop(e, idx)}
+                  onDragEnd={() => { setDraggedId(null); setDragOverIdx(null); }}
+                  className={`flex items-center gap-3 p-3 rounded-lg border transition-all duration-200 ${
+                    isDragging ? "opacity-50" : ""
+                  } ${
+                    isDragOver ? "border-red-500 bg-red-50 dark:bg-red-950/20 ring-2 ring-red-500/20" : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+                  } cursor-grab active:cursor-grabbing`}
+                >
+                  <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-bold shrink-0 ${
+                    idx === 0 ? "bg-red-600 text-white" : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
+                  }`}>
+                    {idx + 1}
+                  </span>
+                  <div className="shrink-0 w-9 h-9 rounded-lg bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+                    <Icon className="h-4 w-4 text-red-600 dark:text-red-400" />
+                  </div>
+                  {entry.custom ? (
+                    <input
+                      type="text"
+                      maxLength={200}
+                      placeholder="Describe your proposed team / interest"
+                      value={customTeam}
+                      onChange={(e) => onCustomTeamChange(e.target.value)}
+                      className="flex-1 px-2 py-1 text-sm rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                    />
+                  ) : (
+                    <span className="flex-1 text-sm font-medium text-gray-900 dark:text-white">{entry.name}</span>
+                  )}
+                  <div className="shrink-0 flex items-center gap-1">
+                    <button type="button" onClick={() => move(idx, idx - 1)} disabled={idx === 0} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 transition-colors" title="Move up">
+                      <ArrowUp className="h-4 w-4" />
+                    </button>
+                    <button type="button" onClick={() => move(idx, idx + 1)} disabled={idx === ranking.length - 1} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 transition-colors" title="Move down">
+                      <ArrowDown className="h-4 w-4" />
+                    </button>
+                    <button type="button" onClick={() => removeTeam(entry.id)} className="p-1 text-red-500 hover:text-red-600 transition-colors" title="Remove from preferences">
+                      <span className="sr-only">Remove {entry.name}</span>
+                      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* ── Available Teams zone ── */}
+      <div className="mt-4">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
+            Available Teams {available.length > 0 && <span className="text-gray-500">({available.length})</span>}
+          </span>
+          {!otherEntry && (
+            <button type="button" onClick={addOther} className="text-xs text-red-600 dark:text-red-400 hover:underline">
+              + Add &ldquo;Other&rdquo; (propose your own)
+            </button>
+          )}
+        </div>
+
+        <div
+          className={`rounded-lg border-2 border-dashed p-4 transition-colors duration-200 ${
+            dropZoneOver ? "border-red-500 bg-red-50/50 dark:bg-red-950/20" : "border-gray-200 dark:border-gray-700"
+          }`}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleAvailableDrop}
+        >
+          {available.length === 0 && !otherEntry ? (
+            <p className="text-xs text-gray-400 dark:text-gray-500 italic text-center py-4">
+              All teams have been added to your preferences.
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {available.map((id) => {
+                const Icon = IconFor(id);
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    draggable
+                    onDragStart={() => setDraggedId(id)}
+                    onClick={() => addTeam(id)}
+                    title="Drag to Your Preferences, or click to add"
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm font-medium text-gray-700 dark:text-gray-300 hover:border-red-300 dark:hover:border-red-700 hover:bg-red-50 dark:hover:bg-red-950/20 transition-all duration-200 cursor-grab active:cursor-grabbing"
+                  >
+                    <Icon className="h-4 w-4 text-red-600 dark:text-red-400" />
+                    {teamName(id)}
+                    <span className="ml-1 text-gray-300 dark:text-gray-600" aria-hidden>+</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeamRanker;

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { createContext, useContext, useReducer, ReactNode, useEffect } from 'react';
-import { Event, TeamMember, BlogPost, FAQ, Job, BoardPosition, Application } from '../types';
+import { Event, TeamMember, BlogPost, FAQ, Job, BoardPosition, Application, ApplicationCampaign, TeamApplication } from '../types';
 import { subscribeToEvents, addEvent as addEventToFirestore, updateEvent as updateEventInFirestore, deleteEvent as deleteEventFromFirestore } from '@/lib/firestore/events';
 import { auth } from '@/lib/firebase-client';
 import { onIdTokenChanged } from 'firebase/auth';
@@ -11,6 +11,9 @@ import { subscribeToFaqs, addFaq as addFaqToFirestore, updateFaq as updateFaqInF
 import { subscribeToJobs, addJob as addJobToFirestore, updateJob as updateJobInFirestore, deleteJob as deleteJobFromFirestore } from '@/lib/firestore/jobs';
 import { deleteBoardApplication, subscribeToBoardApplications } from '@/lib/firestore/boardApplications';
 import { subscribeToPositions, addPosition as addPositionToFirestore, updatePosition as updatePositionInFirestore, deletePosition as deletePositionFromFirestore, movePosition as movePositionInFirestore } from '@/lib/firestore/board-positions'
+import { subscribeToCampaigns, addCampaign as addCampaignToFirestore, updateCampaign as updateCampaignInFirestore, deleteCampaign as deleteCampaignFromFirestore, type CampaignInput } from '@/lib/firestore/applicationCampaigns';
+import { deleteCampaignQuestionsByCampaign } from '@/lib/firestore/campaignQuestions';
+import { deleteTeamApplication, subscribeToTeamApplications } from '@/lib/firestore/teamApplications';
 
 interface AppState {
   events: Event[];
@@ -20,6 +23,8 @@ interface AppState {
   jobs: Job[];
   boardPositions: BoardPosition[];
   applicants: Application[];
+  campaigns: ApplicationCampaign[];
+  teamApplications: TeamApplication[];
   isLoading: boolean;
   error: string | null;
 }
@@ -51,7 +56,9 @@ type AppAction =
   | { type: 'ADD_JOB'; payload: Job }
   | { type: 'UPDATE_JOB'; payload: Job }
   | { type: 'DELETE_JOB'; payload: string }
-  | { type: 'SET_APPLICANTS'; payload: Application[] };
+  | { type: 'SET_APPLICANTS'; payload: Application[] }
+  | { type: 'SET_CAMPAIGNS'; payload: ApplicationCampaign[] }
+  | { type: 'SET_TEAM_APPLICATIONS'; payload: TeamApplication[] };
 
 type FirestoreAction = 
   | { firestoreAction: 'ADD_EVENT'; payload: Omit<Event, 'id'> }
@@ -74,7 +81,11 @@ type FirestoreAction =
   | { firestoreAction: 'ADD_JOB'; payload: Omit<Job, 'id' | 'createdAt'> }
   | { firestoreAction: 'UPDATE_JOB'; payload: Job }
   | { firestoreAction: 'DELETE_JOB'; payload: string }
-  | { firestoreAction: 'DELETE_BOARD_APPLICATION'; payload: string };
+  | { firestoreAction: 'DELETE_BOARD_APPLICATION'; payload: string }
+  | { firestoreAction: 'ADD_CAMPAIGN'; payload: CampaignInput }
+  | { firestoreAction: 'UPDATE_CAMPAIGN'; payload: ApplicationCampaign }
+  | { firestoreAction: 'DELETE_CAMPAIGN'; payload: string }
+  | { firestoreAction: 'DELETE_TEAM_APPLICATION'; payload: string };
 
 const initialState: AppState = {
   events: [],
@@ -84,6 +95,8 @@ const initialState: AppState = {
   jobs: [],
   boardPositions: [],
   applicants: [],
+  campaigns: [],
+  teamApplications: [],
   isLoading: false,
   error: null
 };
@@ -186,6 +199,10 @@ const appReducer = (state: AppState, action: AppAction): AppState => {
       };
     case 'SET_APPLICANTS':
       return { ...state, applicants: action.payload };
+    case 'SET_CAMPAIGNS':
+      return { ...state, campaigns: action.payload };
+    case 'SET_TEAM_APPLICATIONS':
+      return { ...state, teamApplications: action.payload };
     default:
       return state;
   }
@@ -208,6 +225,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     let unsubscribeJobs: (() => void) | null = null;
     let unsubscribeBoardPositions: (() => void) | null = null;
     let unsubscribeBoardApplications: (() => void) | null = null;
+    let unsubscribeCampaigns: (() => void) | null = null;
+    let unsubscribeTeamApplications: (() => void) | null = null;
 
     const subscribe = (includeUnpublished = false) => {
       // includeUnpublished: boolean indicates admin status
@@ -248,6 +267,19 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       } else {
         dispatch({ type: 'SET_APPLICANTS', payload: [] });
       }
+
+      // Team applications: admin-only subscription (campaigns are public, subscribed separately)
+      if (unsubscribeTeamApplications) {
+        try { unsubscribeTeamApplications(); } catch { /* ignore */ }
+        unsubscribeTeamApplications = null;
+      }
+      if (includeUnpublished) {
+        unsubscribeTeamApplications = subscribeToTeamApplications((applications) => {
+          dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: applications as TeamApplication[] });
+        });
+      } else {
+        dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: [] });
+      }
     };
 
     // Initial subscription: assume not admin (public)
@@ -263,6 +295,11 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     });
     const unsubscribeFaqs = subscribeToFaqs((faqs) => {
       dispatch({ type: 'SET_FAQS', payload: faqs });
+    });
+
+    // Public campaign subscription (visible to all visitors; drafts included since admin-only toggle is enforced by status)
+    unsubscribeCampaigns = subscribeToCampaigns((campaigns) => {
+      dispatch({ type: 'SET_CAMPAIGNS', payload: campaigns });
     });
     
 
@@ -294,6 +331,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       }
       if (unsubscribeBoardApplications) {
         try { unsubscribeBoardApplications(); } catch { /* ignore */ }
+      }
+      if (unsubscribeCampaigns) {
+        try { unsubscribeCampaigns(); } catch { /* ignore */ }
+      }
+      if (unsubscribeTeamApplications) {
+        try { unsubscribeTeamApplications(); } catch { /* ignore */ }
       }
       unsubscribeTeamMembers();
       unsubscribeBlogPosts();
@@ -373,6 +416,20 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
             break;
           case 'DELETE_BOARD_APPLICATION':
             await deleteBoardApplication(action.payload);
+            break;
+          case 'ADD_CAMPAIGN':
+            await addCampaignToFirestore(action.payload);
+            break;
+          case 'UPDATE_CAMPAIGN':
+            await updateCampaignInFirestore(action.payload.id, action.payload);
+            break;
+          case 'DELETE_CAMPAIGN':
+            await deleteCampaignFromFirestore(action.payload);
+            // Also clean up campaign questions
+            try { await deleteCampaignQuestionsByCampaign(action.payload); } catch { /* ignore */ }
+            break;
+          case 'DELETE_TEAM_APPLICATION':
+            await deleteTeamApplication(action.payload);
             break;
         }
       } else {

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -24,6 +24,7 @@ interface AppState {
   boardPositions: BoardPosition[];
   applicants: Application[];
   campaigns: ApplicationCampaign[];
+  campaignsLoaded: boolean;
   teamApplications: TeamApplication[];
   isLoading: boolean;
   error: string | null;
@@ -58,6 +59,7 @@ type AppAction =
   | { type: 'DELETE_JOB'; payload: string }
   | { type: 'SET_APPLICANTS'; payload: Application[] }
   | { type: 'SET_CAMPAIGNS'; payload: ApplicationCampaign[] }
+  | { type: 'SET_CAMPAIGNS_LOADED'; payload: boolean }
   | { type: 'SET_TEAM_APPLICATIONS'; payload: TeamApplication[] };
 
 type FirestoreAction = 
@@ -83,7 +85,7 @@ type FirestoreAction =
   | { firestoreAction: 'DELETE_JOB'; payload: string }
   | { firestoreAction: 'DELETE_BOARD_APPLICATION'; payload: string }
   | { firestoreAction: 'ADD_CAMPAIGN'; payload: CampaignInput }
-  | { firestoreAction: 'UPDATE_CAMPAIGN'; payload: ApplicationCampaign }
+  | { firestoreAction: 'UPDATE_CAMPAIGN'; payload: Partial<ApplicationCampaign> }
   | { firestoreAction: 'DELETE_CAMPAIGN'; payload: string }
   | { firestoreAction: 'DELETE_TEAM_APPLICATION'; payload: string };
 
@@ -96,6 +98,7 @@ const initialState: AppState = {
   boardPositions: [],
   applicants: [],
   campaigns: [],
+  campaignsLoaded: false,
   teamApplications: [],
   isLoading: false,
   error: null
@@ -201,6 +204,8 @@ const appReducer = (state: AppState, action: AppAction): AppState => {
       return { ...state, applicants: action.payload };
     case 'SET_CAMPAIGNS':
       return { ...state, campaigns: action.payload };
+    case 'SET_CAMPAIGNS_LOADED':
+      return { ...state, campaignsLoaded: action.payload };
     case 'SET_TEAM_APPLICATIONS':
       return { ...state, teamApplications: action.payload };
     default:
@@ -268,7 +273,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         dispatch({ type: 'SET_APPLICANTS', payload: [] });
       }
 
-      // Team applications: admin-only subscription (campaigns are public, subscribed separately)
+      // Team applications: admin-only subscription
       if (unsubscribeTeamApplications) {
         try { unsubscribeTeamApplications(); } catch { /* ignore */ }
         unsubscribeTeamApplications = null;
@@ -280,6 +285,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       } else {
         dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: [] });
       }
+
+      // Campaigns: public visitors only see open campaigns; admins see all (incl. drafts)
+      if (unsubscribeCampaigns) {
+        try { unsubscribeCampaigns(); } catch { /* ignore */ }
+        unsubscribeCampaigns = null;
+      }
+      unsubscribeCampaigns = subscribeToCampaigns((campaigns) => {
+        dispatch({ type: 'SET_CAMPAIGNS', payload: campaigns });
+        dispatch({ type: 'SET_CAMPAIGNS_LOADED', payload: true });
+      }, { includeAll: includeUnpublished });
     };
 
     // Initial subscription: assume not admin (public)
@@ -297,23 +312,27 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       dispatch({ type: 'SET_FAQS', payload: faqs });
     });
 
-    // Public campaign subscription (visible to all visitors; drafts included since admin-only toggle is enforced by status)
-    unsubscribeCampaigns = subscribeToCampaigns((campaigns) => {
-      dispatch({ type: 'SET_CAMPAIGNS', payload: campaigns });
-    });
-    
-
     // Listen for ID token changes to detect admin claim changes.
+    let currentAdminClaim: boolean | null = null;
+    let authGeneration = 0;
     const idTokenUnsub = onIdTokenChanged(auth, async (user) => {
-      if (!user) {
-        // Not signed in — ensure public subscription
-        subscribe(false);
-        return;
+      const gen = ++authGeneration;
+      let adminClaim = false;
+      if (user) {
+        // Refresh token to ensure custom claims are present
+        try {
+          const tokenResult = await user.getIdTokenResult(true);
+          adminClaim = !!tokenResult.claims.admin;
+        } catch (err) {
+          console.warn('Failed to refresh ID token', err);
+          return;
+        }
       }
-
-      // Refresh token to ensure custom claims are present
-      const tokenResult = await user.getIdTokenResult(true);
-      const adminClaim = !!tokenResult.claims.admin;
+      // Ignore stale auth events that resolved after a newer one applied.
+      if (gen !== authGeneration) return;
+      // Avoid re-subscribing when the admin claim did not change.
+      if (currentAdminClaim === adminClaim) return;
+      currentAdminClaim = adminClaim;
       // Re-subscribe with adminClaim (true/false)
       subscribe(adminClaim);
     });
@@ -418,10 +437,11 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
             await deleteBoardApplication(action.payload);
             break;
           case 'ADD_CAMPAIGN':
-            await addCampaignToFirestore(action.payload);
-            break;
+            return await addCampaignToFirestore(action.payload);
           case 'UPDATE_CAMPAIGN':
-            await updateCampaignInFirestore(action.payload.id, action.payload);
+            if (action.payload.id) {
+              await updateCampaignInFirestore(action.payload.id, action.payload);
+            }
             break;
           case 'DELETE_CAMPAIGN':
             await deleteCampaignFromFirestore(action.payload);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -75,6 +75,8 @@ const __defaultAppState = {
   jobs: [],
   boardPositions: [],
   applicants: [],
+  campaigns: [],
+  teamApplications: [],
   registrationQuestions: [],
   isLoading: false,
   error: null,

--- a/lib/apply-handler.ts
+++ b/lib/apply-handler.ts
@@ -1,0 +1,261 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getTokens } from 'next-firebase-auth-edge';
+import { authConfig } from '@/lib/auth-config';
+import { adminDb } from '@/lib/firebase-admin';
+import admin from 'firebase-admin';
+
+interface AppError extends Error {
+  status?: number;
+  code?: string;
+  retryAfterSeconds?: number;
+}
+
+async function authorizeRequest(req: NextRequest) {
+  try {
+    const tokens = await getTokens(req.cookies, authConfig);
+    if (!tokens) return { ok: false, reason: 'no-auth' };
+    return { ok: true, uid: tokens.decodedToken.uid };
+  } catch (err) {
+    console.warn('getTokens failed', err);
+    return { ok: false, reason: 'invalid-token' };
+  }
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function safeKeyPart(s: string): string {
+  return encodeURIComponent(s);
+}
+
+async function saveFileToStorage(file: File, destPath: string) {
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const bucket = admin.storage().bucket();
+  const gfile = bucket.file(destPath);
+  await gfile.save(buffer, { metadata: { contentType: file.type || 'application/octet-stream' } });
+  const expires = Date.now() + 40 * 24 * 60 * 60 * 1000;
+  const [url] = await gfile.getSignedUrl({ action: 'read', expires });
+  return { path: destPath, url };
+}
+
+const DEFAULT_COOLDOWN_SECONDS = 1 * 60;
+const DEFAULT_MAX_SUBMISSIONS_PER_CAMPAIGN = 1;
+const MAX_MOTIVATION_CHARS = 1500;
+const MIN_MOTIVATION_CHARS = 25;
+const MAX_CUSTOM_ANSWER_CHARS = 3500;
+const MAX_NAME_CHARS = 100;
+const MAX_EMAIL_CHARS = 254;
+const MAX_GENDER_CHARS = 20;
+const MAX_UNIVERSITY_CHARS = 100;
+const MAX_PROGRAM_CHARS = 200;
+const MAX_GRADUATION_YEAR_CHARS = 4;
+const MAX_LINKEDIN_CHARS = 200;
+const MAX_CUSTOM_TEAM_CHARS = 200;
+const MAX_CUSTOM_INTEREST_CHARS = 200;
+const MAX_INTERESTS_ITEMS = 50;
+const MAX_TEAM_RANKING_ITEMS = 20;
+const MAX_WEEKLY_HOURS = 12;
+
+export async function handleApplicationPost(req: NextRequest, applicationType: string) {
+  const authResult = await authorizeRequest(req);
+  if (!authResult.ok) {
+    return NextResponse.json({ error: 'Unauthorized — please sign in to apply.' }, { status: 401 });
+  }
+
+  try {
+    const form = await req.formData();
+
+    const campaignId = (form.get('campaignId') as string) || '';
+    const name = (form.get('name') as string) || '';
+    const email = (form.get('email') as string) || '';
+    const gender = (form.get('gender') as string) || '';
+    const university = (form.get('university') as string) || '';
+    const program = (form.get('program') as string) || '';
+    const graduationYear = (form.get('graduationYear') as string) || '';
+    const linkedin = (form.get('linkedin') as string) || '';
+    const customTeam = (form.get('customTeam') as string) || '';
+    const weeklyHoursRaw = form.get('weeklyHours');
+    const weeklyHours = weeklyHoursRaw ? Number(weeklyHoursRaw) : 0;
+    const motivation = (form.get('motivation') as string) || '';
+    const agree = form.get('agree') === 'true' || form.get('agree') === 'on';
+    const newsletter = form.get('newsletter') === 'true' || form.get('newsletter') === 'on';
+
+    let interests: string[] = [];
+    try { interests = JSON.parse((form.get('interests') as string) || '[]'); } catch { /* empty */ }
+    const customInterest = (form.get('customInterest') as string) || '';
+    let teamRanking: string[] = [];
+    try { teamRanking = JSON.parse((form.get('teamRanking') as string) || '[]'); } catch { /* empty */ }
+    let customAnswers: Record<string, string | string[]> = {};
+    try { customAnswers = JSON.parse((form.get('customAnswers') as string) || '{}'); } catch { /* empty */ }
+
+    if (!campaignId) return NextResponse.json({ error: 'Campaign ID is required' }, { status: 400 });
+    if (!name || !name.trim()) return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+    if (name.length > MAX_NAME_CHARS) return NextResponse.json({ error: `Name must be at most ${MAX_NAME_CHARS} characters` }, { status: 400 });
+    if (!email || !email.trim()) return NextResponse.json({ error: 'Email is required' }, { status: 400 });
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return NextResponse.json({ error: 'Email is not valid' }, { status: 400 });
+    if (email.length > MAX_EMAIL_CHARS) return NextResponse.json({ error: `Email must be at most ${MAX_EMAIL_CHARS} characters` }, { status: 400 });
+    if (gender && gender.length > MAX_GENDER_CHARS) return NextResponse.json({ error: `Gender must be at most ${MAX_GENDER_CHARS} characters` }, { status: 400 });
+    if (university && university.length > MAX_UNIVERSITY_CHARS) return NextResponse.json({ error: `University must be at most ${MAX_UNIVERSITY_CHARS} characters` }, { status: 400 });
+    if (program && program.length > MAX_PROGRAM_CHARS) return NextResponse.json({ error: `Programme must be at most ${MAX_PROGRAM_CHARS} characters` }, { status: 400 });
+    if (graduationYear && graduationYear.length > MAX_GRADUATION_YEAR_CHARS) return NextResponse.json({ error: `Graduation year must be at most ${MAX_GRADUATION_YEAR_CHARS} characters` }, { status: 400 });
+    if (!agree) return NextResponse.json({ error: 'Agreement required' }, { status: 400 });
+    if (!motivation || !motivation.trim()) return NextResponse.json({ error: 'Motivation is required' }, { status: 400 });
+    if (motivation.trim().length < MIN_MOTIVATION_CHARS) return NextResponse.json({ error: `Motivation must be at least ${MIN_MOTIVATION_CHARS} characters` }, { status: 400 });
+    if (motivation.length > MAX_MOTIVATION_CHARS) return NextResponse.json({ error: `Motivation must be at most ${MAX_MOTIVATION_CHARS} characters` }, { status: 400 });
+    if (!linkedin || !linkedin.trim()) return NextResponse.json({ error: 'LinkedIn URL is required' }, { status: 400 });
+    if (linkedin.length > MAX_LINKEDIN_CHARS) return NextResponse.json({ error: `LinkedIn URL must be at most ${MAX_LINKEDIN_CHARS} characters` }, { status: 400 });
+    if (/^javascript:/i.test(linkedin.trim())) return NextResponse.json({ error: 'LinkedIn URL contains an invalid scheme' }, { status: 400 });
+    if (customTeam && customTeam.length > MAX_CUSTOM_TEAM_CHARS) return NextResponse.json({ error: `Custom team must be at most ${MAX_CUSTOM_TEAM_CHARS} characters` }, { status: 400 });
+    if (customInterest && customInterest.length > MAX_CUSTOM_INTEREST_CHARS) return NextResponse.json({ error: `Custom interest must be at most ${MAX_CUSTOM_INTEREST_CHARS} characters` }, { status: 400 });
+    if (!Array.isArray(interests) || interests.length > MAX_INTERESTS_ITEMS) return NextResponse.json({ error: `Interests must be an array with at most ${MAX_INTERESTS_ITEMS} items` }, { status: 400 });
+    if (!Array.isArray(teamRanking) || teamRanking.length > MAX_TEAM_RANKING_ITEMS) return NextResponse.json({ error: `Team ranking must be an array with at most ${MAX_TEAM_RANKING_ITEMS} items` }, { status: 400 });
+    if (!Number.isFinite(weeklyHours) || weeklyHours < 0 || weeklyHours > MAX_WEEKLY_HOURS) return NextResponse.json({ error: `Weekly hours must be between 0 and ${MAX_WEEKLY_HOURS}` }, { status: 400 });
+
+    const campaignSnap = await adminDb.collection('applicationCampaigns').doc(campaignId).get();
+    if (!campaignSnap.exists) return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+    const campaignData = campaignSnap.data() as { status?: string; teams?: string[] };
+    if (campaignData.status !== 'open') return NextResponse.json({ error: 'This campaign is not currently accepting submissions.' }, { status: 400 });
+
+    const campaignTeams = Array.isArray(campaignData.teams) ? campaignData.teams : [];
+    for (const tid of teamRanking) {
+      if (!campaignTeams.includes(tid) && tid !== 'other') {
+        return NextResponse.json({ error: `Team "${tid}" is not available in this campaign` }, { status: 400 });
+      }
+    }
+
+    let resumeFile = form.get('resume') as File | null;
+    let savedResume: { path?: string; url?: string } | null = null;
+    if (resumeFile && resumeFile.size > 0) {
+      if (resumeFile.type !== 'application/pdf' && resumeFile.type !== '') return NextResponse.json({ error: 'Resume must be a PDF' }, { status: 400 });
+      if (resumeFile.size > 3 * 1024 * 1024) return NextResponse.json({ error: 'Resume must be <= 3MB' }, { status: 400 });
+      const header = await resumeFile.slice(0, 5).text();
+      if (header !== '%PDF-') return NextResponse.json({ error: 'Resume does not appear to be a valid PDF' }, { status: 400 });
+      const safeName = resumeFile.name.replace(/[/\\]/g, '_').slice(0, 200);
+      if (!safeName) return NextResponse.json({ error: 'Invalid resume filename' }, { status: 400 });
+      resumeFile = new File([await resumeFile.arrayBuffer()], safeName, { type: resumeFile.type });
+    }
+
+    for (const [key, val] of Object.entries(customAnswers)) {
+      const s = Array.isArray(val) ? val.join(', ') : val;
+      if (typeof s === 'string' && s.length > MAX_CUSTOM_ANSWER_CHARS) {
+        return NextResponse.json({ error: `Answer for "${key}" is too long (max ${MAX_CUSTOM_ANSWER_CHARS} characters)` }, { status: 400 });
+      }
+    }
+
+    const emailNormalized = normalizeEmail(email);
+    const cooldownSeconds = Number(process.env.APPLY_COOLDOWN_SECONDS || DEFAULT_COOLDOWN_SECONDS);
+    const maxPerCampaign = Number(process.env.APPLY_MAX_SUBMISSIONS_PER_CAMPAIGN || DEFAULT_MAX_SUBMISSIONS_PER_CAMPAIGN);
+    const nowMs = Date.now();
+
+    const lockKey = `${safeKeyPart(emailNormalized)}__${safeKeyPart(campaignId)}`;
+    const limitsRef = adminDb.collection('applicationUserLimits').doc(safeKeyPart(emailNormalized));
+    const lockRef = adminDb.collection('applicationCampaignLocks').doc(lockKey);
+    const appRef = adminDb.collection('teamApplications').doc();
+
+    await adminDb.runTransaction(async (tx) => {
+      const [limitsDoc, lockDoc] = await Promise.all([tx.get(limitsRef), tx.get(lockRef)]);
+
+      if (lockDoc.exists) {
+        if (maxPerCampaign <= 0) {
+          // no limit — allow re-submissions
+        } else {
+          const pastCount = (lockDoc.data() as { count?: number } | undefined)?.count || 0;
+          if (pastCount >= maxPerCampaign) {
+            const err = new Error('You have already applied to this campaign.') as AppError;
+            err.status = 409;
+            err.code = 'DUPLICATE_CAMPAIGN';
+            throw err;
+          }
+        }
+      }
+
+      const limitsData = limitsDoc.exists ? limitsDoc.data() : null;
+      const lastAppliedAtMs = typeof (limitsData as { lastAppliedAtMs?: number } | null)?.lastAppliedAtMs === 'number'
+        ? (limitsData as { lastAppliedAtMs: number }).lastAppliedAtMs
+        : 0;
+
+      const cooldownMs = Math.max(0, cooldownSeconds) * 1000;
+      if (cooldownMs > 0 && lastAppliedAtMs && nowMs - lastAppliedAtMs < cooldownMs) {
+        const retryAfterMs = cooldownMs - (nowMs - lastAppliedAtMs);
+        const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+        const err = new Error('Too many submissions. Please try again in a few moments.') as AppError;
+        err.status = 429;
+        err.code = 'RATE_LIMITED';
+        err.retryAfterSeconds = retryAfterSeconds;
+        throw err;
+      }
+
+      tx.set(
+        limitsRef,
+        { lastAppliedAtMs: nowMs, updatedAt: admin.firestore.FieldValue.serverTimestamp() },
+        { merge: true },
+      );
+      const existingCount = (lockDoc.data() as { count?: number } | undefined)?.count || 0;
+      tx.set(lockRef, { count: existingCount + 1, applicationId: appRef.id, campaignId, createdAt: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+
+      tx.set(appRef, {
+        applicationType,
+        campaignId,
+        name,
+        email,
+        emailNormalized,
+        gender: gender || null,
+        university: university || null,
+        program: program || null,
+        graduationYear: graduationYear || null,
+        linkedin: linkedin || null,
+        interests: interests || [],
+        customInterest: customInterest || null,
+        teamRanking: teamRanking || [],
+        customTeam: customTeam || null,
+        weeklyHours: Number.isFinite(weeklyHours) ? weeklyHours : 0,
+        motivation,
+        customAnswers: customAnswers || {},
+        agree: true,
+        newsletter: !!newsletter,
+        resume: null,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    });
+
+    if (resumeFile && resumeFile.size > 0) {
+      try {
+        const timestamp = Date.now();
+        const resumePath = `team-applications/${timestamp}_${resumeFile.name}`;
+        savedResume = await saveFileToStorage(resumeFile, resumePath);
+        await appRef.set({ resume: savedResume }, { merge: true });
+      } catch (uploadErr) {
+        try {
+          await adminDb.runTransaction(async (tx) => {
+            tx.delete(lockRef);
+            tx.delete(appRef);
+          });
+        } catch {
+          // rollback failure ignored
+        }
+        throw uploadErr;
+      }
+    }
+
+    return NextResponse.json({
+      id: appRef.id,
+      campaignId,
+      name,
+      email,
+      resume: savedResume || undefined,
+      applicationType,
+      createdAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    const anyErr = err as { status?: number; message?: string; code?: string; retryAfterSeconds?: number };
+    const status = typeof anyErr?.status === 'number' ? anyErr.status : 500;
+    if (status >= 500) console.error('apply POST error', err);
+    return NextResponse.json(
+      { error: anyErr?.message || 'Server error', code: anyErr?.code, retryAfterSeconds: anyErr?.retryAfterSeconds },
+      { status },
+    );
+  }
+}

--- a/lib/apply-handler.ts
+++ b/lib/apply-handler.ts
@@ -30,6 +30,21 @@ function safeKeyPart(s: string): string {
   return encodeURIComponent(s);
 }
 
+const ANSWER_KEY_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const MAX_CUSTOM_ANSWER_KEYS = 100;
+
+function deadlineMs(value: unknown): number | null {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? null : ms;
+  }
+  if (value && typeof value === 'object' && typeof (value as { toMillis?: unknown }).toMillis === 'function') {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  return null;
+}
+
 async function saveFileToStorage(file: File, destPath: string) {
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
@@ -58,6 +73,11 @@ const MAX_CUSTOM_INTEREST_CHARS = 200;
 const MAX_INTERESTS_ITEMS = 50;
 const MAX_TEAM_RANKING_ITEMS = 20;
 const MAX_WEEKLY_HOURS = 12;
+
+const DEFAULT_STANDARD_FIELDS = [
+  "name", "email", "gender", "university", "program", "graduationYear",
+  "linkedin", "resume", "interests", "teamRanking", "weeklyHours", "motivation",
+];
 
 export async function handleApplicationPost(req: NextRequest, applicationType: string) {
   const authResult = await authorizeRequest(req);
@@ -101,13 +121,8 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
     if (university && university.length > MAX_UNIVERSITY_CHARS) return NextResponse.json({ error: `University must be at most ${MAX_UNIVERSITY_CHARS} characters` }, { status: 400 });
     if (program && program.length > MAX_PROGRAM_CHARS) return NextResponse.json({ error: `Programme must be at most ${MAX_PROGRAM_CHARS} characters` }, { status: 400 });
     if (graduationYear && graduationYear.length > MAX_GRADUATION_YEAR_CHARS) return NextResponse.json({ error: `Graduation year must be at most ${MAX_GRADUATION_YEAR_CHARS} characters` }, { status: 400 });
+    if (graduationYear && !/^\d{4}$/.test(graduationYear.trim())) return NextResponse.json({ error: 'Graduation year must be a 4-digit year' }, { status: 400 });
     if (!agree) return NextResponse.json({ error: 'Agreement required' }, { status: 400 });
-    if (!motivation || !motivation.trim()) return NextResponse.json({ error: 'Motivation is required' }, { status: 400 });
-    if (motivation.trim().length < MIN_MOTIVATION_CHARS) return NextResponse.json({ error: `Motivation must be at least ${MIN_MOTIVATION_CHARS} characters` }, { status: 400 });
-    if (motivation.length > MAX_MOTIVATION_CHARS) return NextResponse.json({ error: `Motivation must be at most ${MAX_MOTIVATION_CHARS} characters` }, { status: 400 });
-    if (!linkedin || !linkedin.trim()) return NextResponse.json({ error: 'LinkedIn URL is required' }, { status: 400 });
-    if (linkedin.length > MAX_LINKEDIN_CHARS) return NextResponse.json({ error: `LinkedIn URL must be at most ${MAX_LINKEDIN_CHARS} characters` }, { status: 400 });
-    if (/^javascript:/i.test(linkedin.trim())) return NextResponse.json({ error: 'LinkedIn URL contains an invalid scheme' }, { status: 400 });
     if (customTeam && customTeam.length > MAX_CUSTOM_TEAM_CHARS) return NextResponse.json({ error: `Custom team must be at most ${MAX_CUSTOM_TEAM_CHARS} characters` }, { status: 400 });
     if (customInterest && customInterest.length > MAX_CUSTOM_INTEREST_CHARS) return NextResponse.json({ error: `Custom interest must be at most ${MAX_CUSTOM_INTEREST_CHARS} characters` }, { status: 400 });
     if (!Array.isArray(interests) || interests.length > MAX_INTERESTS_ITEMS) return NextResponse.json({ error: `Interests must be an array with at most ${MAX_INTERESTS_ITEMS} items` }, { status: 400 });
@@ -116,8 +131,39 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
 
     const campaignSnap = await adminDb.collection('applicationCampaigns').doc(campaignId).get();
     if (!campaignSnap.exists) return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
-    const campaignData = campaignSnap.data() as { status?: string; teams?: string[] };
+    const campaignData = campaignSnap.data() as { status?: string; teams?: string[]; enabledStandardFields?: string[]; deadline?: unknown };
     if (campaignData.status !== 'open') return NextResponse.json({ error: 'This campaign is not currently accepting submissions.' }, { status: 400 });
+
+    const dlMs = deadlineMs(campaignData.deadline);
+    if (dlMs !== null && Date.now() > dlMs) {
+      return NextResponse.json({ error: 'This campaign is no longer accepting applications.' }, { status: 400 });
+    }
+
+    const enabledFields = Array.isArray(campaignData.enabledStandardFields) && campaignData.enabledStandardFields.length > 0
+      ? campaignData.enabledStandardFields
+      : DEFAULT_STANDARD_FIELDS;
+
+    // Only require fields the campaign has enabled
+    if (enabledFields.includes('motivation')) {
+      if (!motivation || !motivation.trim()) return NextResponse.json({ error: 'Motivation is required' }, { status: 400 });
+      if (motivation.trim().length < MIN_MOTIVATION_CHARS) return NextResponse.json({ error: `Motivation must be at least ${MIN_MOTIVATION_CHARS} characters` }, { status: 400 });
+      if (motivation.length > MAX_MOTIVATION_CHARS) return NextResponse.json({ error: `Motivation must be at most ${MAX_MOTIVATION_CHARS} characters` }, { status: 400 });
+    } else if (motivation && motivation.length > MAX_MOTIVATION_CHARS) {
+      return NextResponse.json({ error: `Motivation must be at most ${MAX_MOTIVATION_CHARS} characters` }, { status: 400 });
+    }
+    if (enabledFields.includes('linkedin')) {
+      if (!linkedin || !linkedin.trim()) return NextResponse.json({ error: 'LinkedIn URL is required' }, { status: 400 });
+      if (linkedin.length > MAX_LINKEDIN_CHARS) return NextResponse.json({ error: `LinkedIn URL must be at most ${MAX_LINKEDIN_CHARS} characters` }, { status: 400 });
+      const linkedinNormalized = linkedin.trim().replace(/^https?:\/\//i, '').replace(/^www\./i, '');
+      if (!/^linkedin\.com\/in\/.+$/i.test(linkedinNormalized)) {
+        return NextResponse.json({ error: 'LinkedIn URL must point to a linkedin.com/in/ profile' }, { status: 400 });
+      }
+    } else if (linkedin && linkedin.length > MAX_LINKEDIN_CHARS) {
+      return NextResponse.json({ error: `LinkedIn URL must be at most ${MAX_LINKEDIN_CHARS} characters` }, { status: 400 });
+    }
+    if (enabledFields.includes('teamRanking') && teamRanking.length === 0) {
+      return NextResponse.json({ error: 'At least one team preference is required' }, { status: 400 });
+    }
 
     const campaignTeams = Array.isArray(campaignData.teams) ? campaignData.teams : [];
     for (const tid of teamRanking) {
@@ -128,7 +174,7 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
 
     let resumeFile = form.get('resume') as File | null;
     let savedResume: { path?: string; url?: string } | null = null;
-    if (resumeFile && resumeFile.size > 0) {
+    if (enabledFields.includes('resume') && resumeFile && resumeFile.size > 0) {
       if (resumeFile.type !== 'application/pdf' && resumeFile.type !== '') return NextResponse.json({ error: 'Resume must be a PDF' }, { status: 400 });
       if (resumeFile.size > 3 * 1024 * 1024) return NextResponse.json({ error: 'Resume must be <= 3MB' }, { status: 400 });
       const header = await resumeFile.slice(0, 5).text();
@@ -138,6 +184,14 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
       resumeFile = new File([await resumeFile.arrayBuffer()], safeName, { type: resumeFile.type });
     }
 
+    if (Object.keys(customAnswers).length > MAX_CUSTOM_ANSWER_KEYS) {
+      return NextResponse.json({ error: 'Too many custom answers' }, { status: 400 });
+    }
+    for (const key of Object.keys(customAnswers)) {
+      if (!ANSWER_KEY_RE.test(key)) {
+        return NextResponse.json({ error: 'Invalid answer key' }, { status: 400 });
+      }
+    }
     for (const [key, val] of Object.entries(customAnswers)) {
       const s = Array.isArray(val) ? val.join(', ') : val;
       if (typeof s === 'string' && s.length > MAX_CUSTOM_ANSWER_CHARS) {
@@ -145,13 +199,31 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
       }
     }
 
+    // Enforce required custom questions defined for the campaign
+    const questionsSnap = await adminDb.collection('campaignQuestions').where('campaignId', '==', campaignId).get();
+    for (const doc of questionsSnap.docs) {
+      const q = doc.data() as { question?: string; required?: boolean };
+      if (!q.required) continue;
+      const ans = customAnswers[doc.id];
+      const isEmpty = Array.isArray(ans) ? ans.length === 0 : typeof ans !== 'string' || !ans.trim();
+      if (isEmpty) {
+        return NextResponse.json(
+          { error: `"${q.question || 'This question'}" is required.` },
+          { status: 400 },
+        );
+      }
+    }
+
     const emailNormalized = normalizeEmail(email);
+    // The verified Firebase uid is the authoritative identity for dedup and
+    // rate limiting; email is only a fallback if a uid is somehow unavailable.
+    const identity = authResult.uid || emailNormalized;
     const cooldownSeconds = Number(process.env.APPLY_COOLDOWN_SECONDS || DEFAULT_COOLDOWN_SECONDS);
     const maxPerCampaign = Number(process.env.APPLY_MAX_SUBMISSIONS_PER_CAMPAIGN || DEFAULT_MAX_SUBMISSIONS_PER_CAMPAIGN);
     const nowMs = Date.now();
 
-    const lockKey = `${safeKeyPart(emailNormalized)}__${safeKeyPart(campaignId)}`;
-    const limitsRef = adminDb.collection('applicationUserLimits').doc(safeKeyPart(emailNormalized));
+    const lockKey = `${safeKeyPart(identity)}__${safeKeyPart(campaignId)}`;
+    const limitsRef = adminDb.collection('applicationUserLimits').doc(safeKeyPart(identity));
     const lockRef = adminDb.collection('applicationCampaignLocks').doc(lockKey);
     const appRef = adminDb.collection('teamApplications').doc();
 
@@ -199,20 +271,21 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
       tx.set(appRef, {
         applicationType,
         campaignId,
+        uid: authResult.uid || null,
         name,
         email,
         emailNormalized,
-        gender: gender || null,
-        university: university || null,
-        program: program || null,
-        graduationYear: graduationYear || null,
-        linkedin: linkedin || null,
-        interests: interests || [],
-        customInterest: customInterest || null,
-        teamRanking: teamRanking || [],
-        customTeam: customTeam || null,
-        weeklyHours: Number.isFinite(weeklyHours) ? weeklyHours : 0,
-        motivation,
+        gender: enabledFields.includes('gender') ? gender || null : null,
+        university: enabledFields.includes('university') ? university || null : null,
+        program: enabledFields.includes('program') ? program || null : null,
+        graduationYear: enabledFields.includes('graduationYear') ? graduationYear || null : null,
+        linkedin: enabledFields.includes('linkedin') ? linkedin || null : null,
+        interests: enabledFields.includes('interests') ? (interests || []) : [],
+        customInterest: enabledFields.includes('interests') ? (customInterest || null) : null,
+        teamRanking: enabledFields.includes('teamRanking') ? (teamRanking || []) : [],
+        customTeam: enabledFields.includes('teamRanking') ? (customTeam || null) : null,
+        weeklyHours: enabledFields.includes('weeklyHours') && Number.isFinite(weeklyHours) ? weeklyHours : 0,
+        motivation: enabledFields.includes('motivation') ? motivation : '',
         customAnswers: customAnswers || {},
         agree: true,
         newsletter: !!newsletter,
@@ -228,13 +301,23 @@ export async function handleApplicationPost(req: NextRequest, applicationType: s
         savedResume = await saveFileToStorage(resumeFile, resumePath);
         await appRef.set({ resume: savedResume }, { merge: true });
       } catch (uploadErr) {
+        // Roll back the partial application AND the cooldown/limit so the
+        // applicant can retry immediately after a failed upload.
+        if (savedResume?.path) {
+          try {
+            await admin.storage().bucket().file(savedResume.path).delete();
+          } catch (storageCleanupErr) {
+            console.error('apply storage cleanup failed after upload error', storageCleanupErr);
+          }
+        }
         try {
           await adminDb.runTransaction(async (tx) => {
             tx.delete(lockRef);
+            tx.delete(limitsRef);
             tx.delete(appRef);
           });
-        } catch {
-          // rollback failure ignored
+        } catch (rollbackErr) {
+          console.error('apply rollback failed after upload error', rollbackErr);
         }
         throw uploadErr;
       }

--- a/lib/firestore.rules
+++ b/lib/firestore.rules
@@ -127,9 +127,9 @@ service cloud.firestore {
       allow create, update, delete: if isAdmin();
     }
 
-    // APPLICATION CAMPAIGNS — public read (so applicants see open campaigns); admin write
+    // APPLICATION CAMPAIGNS — public read only for open campaigns (so applicants see them); admin read/write
     match /applicationCampaigns/{campaignId} {
-      allow read: if true;
+      allow read: if isAdmin() || resource.data.status == 'open';
       allow create, update, delete: if isAdmin();
     }
 

--- a/lib/firestore.rules
+++ b/lib/firestore.rules
@@ -127,6 +127,24 @@ service cloud.firestore {
       allow create, update, delete: if isAdmin();
     }
 
+    // APPLICATION CAMPAIGNS — public read (so applicants see open campaigns); admin write
+    match /applicationCampaigns/{campaignId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    // CAMPAIGN QUESTIONS — public read (so applicants see form questions); admin write
+    match /campaignQuestions/{questionId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    // TEAM APPLICATIONS (submissions; API writes via Admin SDK — client read/delete admin-only)
+    match /teamApplications/{applicationId} {
+      allow read: if isAdmin();
+      allow create, update, delete: if isAdmin();
+    }
+
     // REGISTRATION QUESTIONS (global)
     match /registrationQuestions/{rqId} {
       allow read: if true;
@@ -207,6 +225,14 @@ service cloud.firestore {
         request.resource.data.status == 'confirmed' &&
         resource.data.confirmationToken != null &&
         request.resource.data.confirmationToken == null;
+    }
+
+    // APPLICATION LIMITS (anti-spam cooldown & campaign locks — admin cleanup on deletion)
+    match /applicationUserLimits/{emailHash} {
+      allow read, write, delete: if isAdmin();
+    }
+    match /applicationCampaignLocks/{lockKey} {
+      allow read, write, delete: if isAdmin();
     }
 
     // ANALYTICS (client-side dedup with localStorage; guarded increments)

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -13,3 +13,6 @@ export * from './firestore/favorites';
 export * from './firestore/course-categories';
 export * from './firestore/ai-settings';
 export * from './firestore/courses';
+export * from './firestore/applicationCampaigns';
+export * from './firestore/campaignQuestions';
+export * from './firestore/teamApplications';

--- a/lib/firestore/applicationCampaigns.ts
+++ b/lib/firestore/applicationCampaigns.ts
@@ -1,0 +1,92 @@
+import { collection, query, getDocs, addDoc, updateDoc, deleteDoc, onSnapshot, DocumentData, doc, Timestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase-client';
+import { ApplicationCampaign } from '@/types';
+import { ensureString, stripUndefined } from './utils';
+
+const COLLECTION = 'applicationCampaigns';
+
+function ensureStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => String(x));
+  return [];
+}
+
+function ensureTeamInfo(v: unknown): ApplicationCampaign['teamInfo'] | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  const src = v as Record<string, unknown>;
+  const out: Record<string, { name?: string; description?: string }> = {};
+  let hasAny = false;
+  Object.keys(src).forEach((k) => {
+    const val = src[k];
+    if (!val || typeof val !== 'object' || Array.isArray(val)) return;
+    const entry = val as Record<string, unknown>;
+    const name = typeof entry.name === 'string' ? entry.name : undefined;
+    const description = typeof entry.description === 'string' ? entry.description : undefined;
+    if (name || description) {
+      out[k] = { ...(name ? { name } : {}), ...(description ? { description } : {}) };
+      hasAny = true;
+    }
+  });
+  return hasAny ? out : undefined;
+}
+
+function docToCampaign(id: string, data: Record<string, unknown>): ApplicationCampaign {
+  return {
+    id,
+    title: ensureString(data.title),
+    subtitle: ensureString(data.subtitle),
+    description: ensureString(data.description),
+    deadline: ensureString(data.deadline),
+    status: ((): ApplicationCampaign['status'] => {
+      const s = ensureString(data.status);
+      if (s === 'open' || s === 'closed' || s === 'draft') return s;
+      return 'draft';
+    })(),
+    teams: ensureStringArray(data.teams),
+    teamInfo: ensureTeamInfo(data.teamInfo),
+    enabledStandardFields: ensureStringArray(data.enabledStandardFields),
+    createdAt: data.createdAt as string | Timestamp | undefined,
+  };
+}
+
+export type CampaignInput = Omit<ApplicationCampaign, 'id' | 'createdAt'>;
+
+export async function getCampaigns(): Promise<ApplicationCampaign[]> {
+  const snapshot = await getDocs(collection(db, COLLECTION));
+  return snapshot.docs.map((d) => {
+    const data = d.data() as Record<string, unknown>;
+    return docToCampaign(d.id, data);
+  });
+}
+
+export async function addCampaign(campaign: CampaignInput): Promise<string> {
+  const payload = stripUndefined({
+    title: campaign.title,
+    subtitle: campaign.subtitle,
+    description: campaign.description,
+    deadline: campaign.deadline,
+    status: campaign.status,
+    teams: campaign.teams,
+    enabledStandardFields: campaign.enabledStandardFields,
+  } as Record<string, unknown>);
+  const ref = await addDoc(collection(db, COLLECTION), { ...payload, createdAt: new Date().toISOString() });
+  return ref.id;
+}
+
+export async function updateCampaign(id: string, campaign: Partial<ApplicationCampaign>): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: _omit, createdAt: _omit2, ...rest } = campaign;
+  const ref = doc(db, COLLECTION, id);
+  await updateDoc(ref, stripUndefined(rest) as DocumentData);
+}
+
+export async function deleteCampaign(id: string): Promise<void> {
+  await deleteDoc(doc(db, COLLECTION, id));
+}
+
+export function subscribeToCampaigns(callback: (campaigns: ApplicationCampaign[]) => void) {
+  const q = query(collection(db, COLLECTION));
+  return onSnapshot(q, (snapshot) => {
+    const list = snapshot.docs.map((d) => docToCampaign(d.id, d.data() as Record<string, unknown>));
+    callback(list);
+  });
+}

--- a/lib/firestore/applicationCampaigns.ts
+++ b/lib/firestore/applicationCampaigns.ts
@@ -1,4 +1,4 @@
-import { collection, query, getDocs, addDoc, updateDoc, deleteDoc, onSnapshot, DocumentData, doc, Timestamp } from 'firebase/firestore';
+import { collection, query, getDocs, addDoc, updateDoc, deleteDoc, onSnapshot, DocumentData, doc, Timestamp, where } from 'firebase/firestore';
 import { db } from '@/lib/firebase-client';
 import { ApplicationCampaign } from '@/types';
 import { ensureString, stripUndefined } from './utils';
@@ -66,6 +66,7 @@ export async function addCampaign(campaign: CampaignInput): Promise<string> {
     deadline: campaign.deadline,
     status: campaign.status,
     teams: campaign.teams,
+    teamInfo: campaign.teamInfo,
     enabledStandardFields: campaign.enabledStandardFields,
   } as Record<string, unknown>);
   const ref = await addDoc(collection(db, COLLECTION), { ...payload, createdAt: new Date().toISOString() });
@@ -83,8 +84,11 @@ export async function deleteCampaign(id: string): Promise<void> {
   await deleteDoc(doc(db, COLLECTION, id));
 }
 
-export function subscribeToCampaigns(callback: (campaigns: ApplicationCampaign[]) => void) {
-  const q = query(collection(db, COLLECTION));
+export function subscribeToCampaigns(callback: (campaigns: ApplicationCampaign[]) => void, opts?: { includeAll?: boolean }) {
+  // Public visitors only see open campaigns; admins pass includeAll to see drafts too
+  const q = opts?.includeAll
+    ? query(collection(db, COLLECTION))
+    : query(collection(db, COLLECTION), where('status', '==', 'open'));
   return onSnapshot(q, (snapshot) => {
     const list = snapshot.docs.map((d) => docToCampaign(d.id, d.data() as Record<string, unknown>));
     callback(list);

--- a/lib/firestore/campaignQuestions.ts
+++ b/lib/firestore/campaignQuestions.ts
@@ -1,0 +1,77 @@
+import { collection, query, where, getDocs, addDoc, updateDoc, deleteDoc, onSnapshot, DocumentData, doc } from 'firebase/firestore';
+import { db } from '@/lib/firebase-client';
+import { CampaignQuestion } from '@/types';
+import { ensureString, ensureNumber, stripUndefined } from './utils';
+
+const COLLECTION = 'campaignQuestions';
+
+function ensureStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => String(x));
+  return [];
+}
+
+function isValidType(t: unknown): t is CampaignQuestion['type'] {
+  return t === 'text' || t === 'textarea' || t === 'select' || t === 'radio' || t === 'checkbox';
+}
+
+function docToQuestion(id: string, data: Record<string, unknown>): CampaignQuestion {
+  const type = isValidType(data.type) ? data.type : 'text';
+  return {
+    id,
+    campaignId: ensureString(data.campaignId),
+    question: ensureString(data.question),
+    type,
+    options: ensureStringArray(data.options),
+    required: !!data.required,
+    order: ensureNumber(data.order, 0),
+  };
+}
+
+export type CampaignQuestionInput = Omit<CampaignQuestion, 'id'>;
+
+export async function getCampaignQuestions(campaignId: string): Promise<CampaignQuestion[]> {
+  const q = query(collection(db, COLLECTION), where('campaignId', '==', campaignId));
+  const snapshot = await getDocs(q);
+  const list = snapshot.docs.map((d) => docToQuestion(d.id, d.data() as Record<string, unknown>));
+  list.sort((a, b) => a.order - b.order);
+  return list;
+}
+
+export async function addCampaignQuestion(q: CampaignQuestionInput): Promise<string> {
+  const payload = stripUndefined({
+    campaignId: q.campaignId,
+    question: q.question,
+    type: q.type,
+    options: q.options,
+    required: q.required,
+    order: q.order,
+  } as Record<string, unknown>);
+  const ref = await addDoc(collection(db, COLLECTION), payload);
+  return ref.id;
+}
+
+export async function updateCampaignQuestion(id: string, q: Partial<CampaignQuestion>): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: _omit, campaignId: _omit2, ...rest } = q;
+  const ref = doc(db, COLLECTION, id);
+  await updateDoc(ref, stripUndefined(rest) as DocumentData);
+}
+
+export async function deleteCampaignQuestion(id: string): Promise<void> {
+  await deleteDoc(doc(db, COLLECTION, id));
+}
+
+export async function deleteCampaignQuestionsByCampaign(campaignId: string): Promise<void> {
+  const q = query(collection(db, COLLECTION), where('campaignId', '==', campaignId));
+  const snapshot = await getDocs(q);
+  await Promise.all(snapshot.docs.map((d) => deleteDoc(d.ref)));
+}
+
+export function subscribeToCampaignQuestions(campaignId: string, callback: (questions: CampaignQuestion[]) => void) {
+  const q = query(collection(db, COLLECTION), where('campaignId', '==', campaignId));
+  return onSnapshot(q, (snapshot) => {
+    const list = snapshot.docs.map((d) => docToQuestion(d.id, d.data() as Record<string, unknown>));
+    list.sort((a, b) => a.order - b.order);
+    callback(list);
+  });
+}

--- a/lib/firestore/teamApplications.ts
+++ b/lib/firestore/teamApplications.ts
@@ -1,0 +1,113 @@
+import { collection, onSnapshot, deleteDoc, doc, Timestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase-client';
+import { TeamApplication } from '@/types';
+import { ensureString, ensureNumber } from './utils';
+
+const COLLECTION = 'teamApplications';
+
+function ensureStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => String(x));
+  return [];
+}
+
+function ensureStringRecord(v: unknown): Record<string, string | string[]> {
+  if (v && typeof v === 'object' && !Array.isArray(v)) {
+    const obj = v as Record<string, unknown>;
+    const out: Record<string, string | string[]> = {};
+    Object.keys(obj).forEach((k) => {
+      const val = obj[k];
+      if (typeof val === 'string') out[k] = val;
+      else if (Array.isArray(val)) out[k] = val.map((x) => String(x));
+    });
+    return out;
+  }
+  return {};
+}
+
+function docToApplication(id: string, data: Record<string, unknown>): TeamApplication {
+  return {
+    id,
+    campaignId: ensureString(data.campaignId),
+    name: ensureString(data.name),
+    email: ensureString(data.email),
+    emailNormalized: ensureString(data.emailNormalized) || undefined,
+    gender: typeof data.gender === 'string' ? data.gender : undefined,
+    university: typeof data.university === 'string' ? data.university : undefined,
+    program: typeof data.program === 'string' ? data.program : undefined,
+    graduationYear: typeof data.graduationYear === 'string' ? data.graduationYear : undefined,
+    linkedin: typeof data.linkedin === 'string' ? data.linkedin : undefined,
+    resume: typeof data.resume === 'object' ? (data.resume as { path?: string; url?: string } | null) : null,
+    interests: ensureStringArray(data.interests),
+    teamRanking: ensureStringArray(data.teamRanking),
+    customTeam: typeof data.customTeam === 'string' ? data.customTeam : undefined,
+    weeklyHours: typeof data.weeklyHours === 'number' ? data.weeklyHours : ensureNumber(data.weeklyHours, 0),
+    motivation: typeof data.motivation === 'string' ? data.motivation : undefined,
+    customAnswers: ensureStringRecord(data.customAnswers),
+    agree: typeof data.agree === 'boolean' ? data.agree : undefined,
+    newsletter: typeof data.newsletter === 'boolean' ? data.newsletter : undefined,
+    createdAt: data.createdAt as string | Timestamp | undefined,
+  };
+}
+
+function applicationSortKey(createdAt: TeamApplication['createdAt']): number {
+  if (!createdAt) return 0;
+  if (typeof createdAt === 'string') {
+    const t = new Date(createdAt).getTime();
+    return Number.isNaN(t) ? 0 : t;
+  }
+  if (createdAt instanceof Timestamp) return createdAt.toMillis();
+  return 0;
+}
+
+export async function deleteTeamApplication(id: string): Promise<void> {
+  await deleteDoc(doc(db, COLLECTION, id));
+}
+
+/**
+ * Delete an application together with its campaign lock and cooldown limit docs.
+ * Call this instead of deleteTeamApplication when the admin deletes a submission.
+ */
+export async function deleteTeamApplicationWithLimits(
+  id: string,
+  emailNormalized: string,
+  campaignId: string,
+): Promise<void> {
+  const { deleteDoc: del, doc: d } = await import('firebase/firestore');
+  const sanitize = (s: string) => encodeURIComponent(s);
+  const lockKey = `${sanitize(emailNormalized)}__${sanitize(campaignId)}`;
+  await Promise.all([
+    deleteDoc(doc(db, COLLECTION, id)),
+    del(d(db, 'applicationCampaignLocks', lockKey)),
+    del(d(db, 'applicationUserLimits', sanitize(emailNormalized))),
+  ]);
+}
+
+export function subscribeToTeamApplications(callback: (applications: TeamApplication[]) => void) {
+  return onSnapshot(collection(db, COLLECTION), (snapshot) => {
+    const list = snapshot.docs.map((d) => docToApplication(d.id, d.data() as Record<string, unknown>));
+    list.sort((a, b) => applicationSortKey(b.createdAt) - applicationSortKey(a.createdAt));
+    callback(list);
+  });
+}
+
+export async function listTeamApplicationsByCampaign(campaignId: string): Promise<TeamApplication[]> {
+  const { getDocs, query, where } = await import('firebase/firestore');
+  const q = query(collection(db, COLLECTION), where('campaignId', '==', campaignId));
+  const snapshot = await getDocs(q);
+  const list = snapshot.docs.map((d) => docToApplication(d.id, d.data() as Record<string, unknown>));
+  list.sort((a, b) => applicationSortKey(b.createdAt) - applicationSortKey(a.createdAt));
+  return list;
+}
+
+export async function getTeamApplicationByEmail(email: string, campaignId: string): Promise<TeamApplication | null> {
+  const { getDocs, query, where } = await import('firebase/firestore');
+  const q = query(
+    collection(db, COLLECTION),
+    where('emailNormalized', '==', email.trim().toLowerCase()),
+    where('campaignId', '==', campaignId),
+  );
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) return null;
+  const doc = snapshot.docs[0];
+  return docToApplication(doc.id, doc.data() as Record<string, unknown>);
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -234,3 +234,59 @@ export interface Application {
   /** ISO string from some writes; Firestore Timestamp from server / API */
   createdAt?: string | Timestamp;
 };
+
+// ---------------------------------------------------------------------------
+// Application campaigns (team applications) — replaces board-apply
+// ---------------------------------------------------------------------------
+
+export type CampaignStatus = 'open' | 'closed' | 'draft';
+
+export type CustomQuestionType = 'text' | 'textarea' | 'select' | 'radio' | 'checkbox';
+
+export interface CampaignQuestion {
+  id: string;
+  campaignId: string;
+  question: string;
+  type: CustomQuestionType;
+  options?: string[];
+  required: boolean;
+  order: number;
+}
+
+export interface ApplicationCampaign {
+  id: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  deadline: string;
+  status: CampaignStatus;
+  teams: string[];
+  /** Optional per-team overrides keyed by team id. Use this to customise the team name or
+   *  description shown to applicants in step 1 instead of the generic fallback text. */
+  teamInfo?: Record<string, { name?: string; description?: string }>;
+  enabledStandardFields: string[];
+  createdAt?: string | Timestamp;
+}
+
+export interface TeamApplication {
+  id: string;
+  campaignId: string;
+  name: string;
+  email: string;
+  emailNormalized?: string;
+  gender?: string;
+  university?: string;
+  program?: string;
+  graduationYear?: string;
+  linkedin?: string;
+  resume?: { path?: string; url?: string } | null;
+  interests?: string[];
+  teamRanking?: string[];
+  customTeam?: string;
+  weeklyHours?: number;
+  motivation?: string;
+  customAnswers?: Record<string, string | string[]>;
+  agree?: boolean;
+  newsletter?: boolean;
+  createdAt?: string | Timestamp;
+}


### PR DESCRIPTION
## Summary

Adds a full team-application portal for UU AI Society: an applicant-facing wizard, an admin dashboard for managing recruitment campaigns and submissions, and a hardened submission API.

## What's included

### Applicant side
- **5-step application wizard** (`/apply/team`) with team preference ranking, resume upload, custom questions, and review step
- **Apply landing page** (`/apply`) listing application types, reusing the shared `Card`/`Tag`/`Button` components
- Wizard **gates on campaign deadline** and **required custom questions**; disabled fields are excluded from the submitted form
- Header **Apply CTA** is hidden when no open campaign exists and restyled to fit the homepage hero
- Login redirect guarded against open/protocol-relative redirects

### Admin side
- **Campaign builder** with custom questions (structured option editor instead of free-text textarea), team/field selection, and deadline/status
- **Campaign submissions view** with search, team filter, expandable details, and readable custom-answer labels
- **Status toggle** (Open/Draft/Closed) directly on campaign cards — no need to open the editor
- **Animated tab transitions** (directional slide based on tab position) and page/modal enter animations

### API / data layer
- Submission API hardened: **uid-bound** rate limiting/dedup, server-side enforcement of **required custom questions** and **deadline**, disabled-field pruning, LinkedIn profile validation, custom-answer key validation, and storage cleanup on upload failure
- Firestore rules restrict campaign reads to open campaigns (admins see all)
- `AppContext` improvements: stale admin re-subscription race guard, dedup, and a `campaignsLoaded` flag so loading states resolve correctly

## Testing
- 66 unit suites / 792 tests passing, including new tests for the submission API, wizard page, header, TeamRanker, applications tab, and campaign builder
- `npm run lint` and `tsc --noEmit` clean