### PR TITLE
Fix infinite reload loop on mobile + mobile UX fixes + auth flow hardening

### DIFF
--- a/__tests__/app/application/page.test.tsx
+++ b/__tests__/app/application/page.test.tsx
@@ -1,0 +1,24 @@
+import ApplicationPage from '@/app/application/page';
+
+const mockRedirect = jest.fn(() => {
+  throw new Error('NEXT_REDIRECT');
+});
+
+jest.mock('next/navigation', () => ({
+  redirect: (path: string) => {
+    mockRedirect(path);
+    throw new Error('NEXT_REDIRECT');
+  },
+}));
+
+describe('app/application (legacy route)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects server-side to the team application flow instead of a client-side hash jump', () => {
+    expect(() => ApplicationPage()).toThrow('NEXT_REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).toHaveBeenCalledWith('/apply/team');
+  });
+});

--- a/__tests__/app/login/page.test.tsx
+++ b/__tests__/app/login/page.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@/components/ui/LoginModal', () => ({
 describe('LoginPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    global.__setAdminState?.(null)
   })
 
   it('renders the login modal', () => {
@@ -45,5 +46,24 @@ describe('LoginPage', () => {
     const mainDiv = container.firstChild as HTMLElement
     expect(mainDiv.className).toContain('bg-gray-50')
     expect(mainDiv.className).toContain('dark:bg-gray-900')
+  })
+
+  it('shows an account-creation notice for a signed-in user without a profile', () => {
+    global.__setAdminState?.({ user: { uid: 'u1' }, profileLoading: false, profile: null })
+    render(<LoginPage />)
+    expect(screen.getByText(/hasn't created a profile yet/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'create an account' })).toHaveAttribute('href', '/join')
+    global.__setAdminState?.(null)
+  })
+
+  it('hides the account-creation notice for members with a complete profile', () => {
+    global.__setAdminState?.({
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: { id: 'u1', isMember: true, privacyAcceptedAt: '2026-01-01T00:00:00Z' },
+    })
+    render(<LoginPage />)
+    expect(screen.queryByText(/hasn't created a profile yet/)).not.toBeInTheDocument()
+    global.__setAdminState?.(null)
   })
 })

--- a/__tests__/app/pages/join-page.test.tsx
+++ b/__tests__/app/pages/join-page.test.tsx
@@ -11,8 +11,6 @@ jest.mock('@/lib/firebase-client', () => {
       }),
       _callbackHolder: callbackHolder,
     },
-    signInWithGooglePopup: jest.fn(),
-    signInWithGithubPopup: jest.fn(),
   }
 })
 
@@ -36,15 +34,6 @@ jest.mock('@/utils/seo', () => ({
   updatePageMeta: jest.fn(),
 }))
 
-jest.mock('@hugeicons/react', () => ({
-  HugeiconsIcon: ({ icon }: { icon: string }) => <span data-testid="hugeicon">{String(icon)}</span>,
-}))
-
-jest.mock('@hugeicons/core-free-icons', () => ({
-  GoogleIcon: 'google-icon',
-  GithubIcon: 'github-icon',
-}))
-
 async function triggerAuthCallback(user: Record<string, unknown> | null) {
   const firebase = jest.requireMock('@/lib/firebase-client') as {
     auth: { _callbackHolder: { current: ((u: unknown) => Promise<void> | void) | null } }
@@ -61,14 +50,6 @@ function mockedUsers() {
     getUserProfile: jest.Mock
     upsertUserProfile: jest.Mock
     updateUserProfile: jest.Mock
-  }
-}
-
-function mockedFirebase() {
-  return jest.requireMock('@/lib/firebase-client') as {
-    auth: { _callbackHolder: { current: ((u: unknown) => Promise<void> | void) | null } }
-    signInWithGooglePopup: jest.Mock
-    signInWithGithubPopup: jest.Mock
   }
 }
 
@@ -97,25 +78,6 @@ describe('JoinPage', () => {
   })
 
   describe('logged out', () => {
-    it('renders sign-in buttons', () => {
-      render(<JoinPage />)
-      expect(screen.getByText(/Sign in or Create Account/)).toBeInTheDocument()
-      expect(screen.getByText(/Continue with Google/)).toBeInTheDocument()
-      expect(screen.getByText(/Continue with GitHub/)).toBeInTheDocument()
-    })
-
-    it('calls signInWithGooglePopup on Google button click', async () => {
-      render(<JoinPage />)
-      fireEvent.click(screen.getByText(/Continue with Google/))
-      await waitFor(() => expect(mockedFirebase().signInWithGooglePopup).toHaveBeenCalled())
-    })
-
-    it('calls signInWithGithubPopup on GitHub button click', async () => {
-      render(<JoinPage />)
-      fireEvent.click(screen.getByText(/Continue with GitHub/))
-      await waitFor(() => expect(mockedFirebase().signInWithGithubPopup).toHaveBeenCalled())
-    })
-
     it('renders already-a-member section', () => {
       render(<JoinPage />)
       expect(screen.getByText('Already a member?')).toBeInTheDocument()

--- a/__tests__/components/common/registration-gate.test.tsx
+++ b/__tests__/components/common/registration-gate.test.tsx
@@ -14,10 +14,42 @@ jest.mock('@/lib/firestore', () => ({
   getUserProfile: jest.fn(),
 }))
 
+// Mutable admin state so tests can simulate signed-in members (the global jest.setup.ts mock only covers the anonymous case).
+const mockAdminState = {
+  user: null,
+  loading: false,
+  profileLoading: false,
+  profile: null,
+  isAdmin: false,
+  isSuperAdmin: false,
+  claims: null,
+  signInWithGoogle: jest.fn(),
+  logout: jest.fn(),
+}
+
+jest.mock('@/hooks/useAdmin', () => ({
+  useAdmin: () => mockAdminState,
+  refreshProfile: jest.fn(),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => global.__mockPathname || '',
+}))
+
 describe('RegistrationGate', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     global.__mockPathname = '/'
+    Object.assign(mockAdminState, {
+      user: null,
+      loading: false,
+      profileLoading: false,
+      profile: null,
+      isAdmin: false,
+      isSuperAdmin: false,
+      claims: null,
+    })
   })
 
   it('renders nothing', () => {
@@ -25,14 +57,87 @@ describe('RegistrationGate', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('does not redirect on public paths', () => {
-    jest.requireMock('@/lib/firebase-client').auth.onAuthStateChanged
-      .mockImplementation((cb: (u: unknown) => void) => {
-        cb({ uid: '123' })
-        return unsubscribe
-      })
-    global.__mockPathname = '/'
+  it('does not sign out anonymous visitors', () => {
+    global.__mockPathname = '/account'
     render(<RegistrationGate />)
+    expect(mockAdminState.logout).not.toHaveBeenCalled()
     expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('does not sign out a member with a complete profile', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: { id: 'u1', isMember: true, privacyAcceptedAt: '2026-01-01T00:00:00Z' },
+    })
+    global.__mockPathname = '/account'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).not.toHaveBeenCalled()
+  })
+
+  it('signs out an incomplete-profile user who navigates off /join', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: null,
+    })
+    global.__mockPathname = '/account'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).toHaveBeenCalledTimes(1)
+  })
+
+  it('signs out an incomplete-profile user browsing public pages', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: { id: 'u1', isMember: true }, // missing privacyAcceptedAt
+    })
+    global.__mockPathname = '/events'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not sign out an incomplete-profile user while on /join', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: null,
+    })
+    global.__mockPathname = '/join'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).not.toHaveBeenCalled()
+  })
+
+  it('does not sign out an incomplete-profile user on the login page', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: null,
+    })
+    global.__mockPathname = '/login'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).not.toHaveBeenCalled()
+  })
+
+  it('does not sign out an incomplete-profile user on the privacy page', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: false,
+      profile: null,
+    })
+    global.__mockPathname = '/privacy'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).not.toHaveBeenCalled()
+  })
+
+  it('waits for the profile lookup before deciding', () => {
+    Object.assign(mockAdminState, {
+      user: { uid: 'u1' },
+      profileLoading: true,
+      profile: null,
+    })
+    global.__mockPathname = '/account'
+    render(<RegistrationGate />)
+    expect(mockAdminState.logout).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/components/ui/login-modal.test.tsx
+++ b/__tests__/components/ui/login-modal.test.tsx
@@ -4,15 +4,28 @@ import LoginCard from '@/components/ui/LoginModal'
 
 const mockSignInWithGooglePopup = jest.fn()
 const mockSignInWithGithubPopup = jest.fn()
+const mockGetUserProfile = jest.fn()
+const mockRouterPush = jest.fn()
 
 jest.mock('@/lib/firebase-client', () => ({
   signInWithGooglePopup: (...args: unknown[]) => mockSignInWithGooglePopup(...args),
   signInWithGithubPopup: (...args: unknown[]) => mockSignInWithGithubPopup(...args),
 }))
 
+jest.mock('@/lib/firestore', () => ({
+  getUserProfile: (...args: unknown[]) => mockGetUserProfile(...args),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+const mockUser = { uid: 'u1' }
+
 describe('LoginCard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGetUserProfile.mockResolvedValue({ id: 'u1', isMember: true, privacyAcceptedAt: '2026-01-01T00:00:00Z' })
   })
 
   it('renders login heading and description', () => {
@@ -38,20 +51,61 @@ describe('LoginCard', () => {
   })
 
   it('calls signInWithGooglePopup and after when Google button is clicked', async () => {
-    mockSignInWithGooglePopup.mockResolvedValue(undefined)
+    mockSignInWithGooglePopup.mockResolvedValue(mockUser)
     const after = jest.fn()
     render(<LoginCard after={after} />)
     await userEvent.click(screen.getByText(/Continue with Google/))
     expect(mockSignInWithGooglePopup).toHaveBeenCalledTimes(1)
+    expect(mockGetUserProfile).toHaveBeenCalledWith('u1')
     expect(after).toHaveBeenCalledTimes(1)
+    expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
   it('calls signInWithGithubPopup and after when GitHub button is clicked', async () => {
-    mockSignInWithGithubPopup.mockResolvedValue(undefined)
+    mockSignInWithGithubPopup.mockResolvedValue(mockUser)
     const after = jest.fn()
     render(<LoginCard after={after} />)
     await userEvent.click(screen.getByText(/Continue with GitHub/))
     expect(mockSignInWithGithubPopup).toHaveBeenCalledTimes(1)
+    expect(after).toHaveBeenCalledTimes(1)
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /join when the account has not created a profile', async () => {
+    mockSignInWithGooglePopup.mockResolvedValue(mockUser)
+    mockGetUserProfile.mockResolvedValue(null)
+    const after = jest.fn()
+    render(<LoginCard after={after} />)
+    await userEvent.click(screen.getByText(/Continue with Google/))
+    expect(mockRouterPush).toHaveBeenCalledWith('/join')
+    expect(after).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /join when the profile is incomplete', async () => {
+    mockSignInWithGooglePopup.mockResolvedValue(mockUser)
+    mockGetUserProfile.mockResolvedValue({ id: 'u1', isMember: true }) // missing privacyAcceptedAt
+    const after = jest.fn()
+    render(<LoginCard after={after} />)
+    await userEvent.click(screen.getByText(/Continue with Google/))
+    expect(mockRouterPush).toHaveBeenCalledWith('/join')
+    expect(after).not.toHaveBeenCalled()
+  })
+
+  it('shows an error instead of silently failing when sign-in rejects', async () => {
+    mockSignInWithGooglePopup.mockRejectedValue(new Error('auth/popup-blocked'))
+    const after = jest.fn()
+    render(<LoginCard after={after} />)
+    await userEvent.click(screen.getByText(/Continue with Google/))
+    expect(screen.getByRole('alert')).toHaveTextContent('auth/popup-blocked')
+    expect(after).not.toHaveBeenCalled()
+  })
+
+  it('still calls after when the profile lookup fails', async () => {
+    mockSignInWithGooglePopup.mockResolvedValue(mockUser)
+    mockGetUserProfile.mockRejectedValue(new Error('network'))
+    const after = jest.fn()
+    render(<LoginCard after={after} />)
+    await userEvent.click(screen.getByText(/Continue with Google/))
     expect(after).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/contexts/AppContext.test.tsx
+++ b/__tests__/contexts/AppContext.test.tsx
@@ -166,6 +166,20 @@ describe('AppContext', () => {
     expect(subscribeToBlogPosts).toHaveBeenLastCalledWith(expect.any(Function), { includeUnpublished: true });
   });
 
+  it('does not tear down and re-create listeners when the id token resolves with the same (non-admin) claim', async () => {
+    // Regression: the initial subscribe() is already public, so a non-admin first fire must be a no-op (no listener churn).
+    renderApp();
+    await waitFor(() => expect(subscribeToBlogPosts).toHaveBeenCalledTimes(1));
+    act(() => {
+      idTokenCallback!({ uid: 'user-1', getIdTokenResult: () => Promise.resolve({ claims: {} }) });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(subscribeToBlogPosts).toHaveBeenCalledTimes(1);
+    expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+  });
+
   it('throws useApp outside provider', () => {
     expect(() => renderHook(() => useApp())).toThrow('useApp must be used within an AppProvider');
   });

--- a/__tests__/hooks/useAdmin.test.ts
+++ b/__tests__/hooks/useAdmin.test.ts
@@ -227,4 +227,61 @@ describe('useAdmin', () => {
     // this consumer from the local listener set, so mockUnsubscribe stays unused.
     expect(mockUnsubscribe).not.toHaveBeenCalled();
   });
+
+  it('ignores a stale auth event that resolves after a newer one (prevents user flicker)', async () => {
+    let resolveClaims!: (v: { claims: Record<string, boolean> }) => void;
+    getIdTokenResult.mockReturnValue(new Promise((res) => { resolveClaims = res; }));
+    const { result } = loadHook();
+    await waitFor(() => expect(authCallback).not.toBeNull());
+    const staleUser = { uid: 'test-uid', email: 'a@example.com' } as User;
+    const pending = authCallback!(staleUser);
+    // A sign-out event fires while the stale user's token resolution is still in flight.
+    await act(async () => {
+      await authCallback!(null);
+    });
+    expect(result.current.user).toBeNull();
+    // The stale resolution must not re-assert the old user after sign-out.
+    await act(async () => {
+      resolveClaims({ claims: { admin: true } });
+      await pending;
+    });
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('refreshProfile refetches the profile and publishes it to the store', async () => {
+    getIdTokenResult.mockResolvedValue({ claims: {} });
+    getUserProfile
+      .mockResolvedValueOnce({ id: 'test-uid', name: 'OldName' })
+      .mockResolvedValue({ id: 'test-uid', name: 'NewName', isMember: true, privacyAcceptedAt: '2026-01-01T00:00:00Z' });
+    mockAuth.currentUser = mockUser;
+    const { result } = loadHook();
+    await waitFor(() => expect(authCallback).not.toBeNull());
+    await act(async () => {
+      await authCallback!(mockUser);
+    });
+    expect(result.current.profile).toEqual({ id: 'test-uid', name: 'OldName' });
+
+    const { refreshProfile } = jest.requireMock('@/hooks/useAdmin') as typeof import('@/hooks/useAdmin');
+    await act(async () => {
+      await refreshProfile();
+    });
+    expect(getUserProfile).toHaveBeenLastCalledWith('test-uid');
+    expect(result.current.profile).toEqual({ id: 'test-uid', name: 'NewName', isMember: true, privacyAcceptedAt: '2026-01-01T00:00:00Z' });
+  });
+
+  it('refreshProfile is a no-op when signed out', async () => {
+    const { result } = loadHook();
+    await waitFor(() => expect(authCallback).not.toBeNull());
+    await act(async () => {
+      await authCallback!(null);
+    });
+    const { refreshProfile } = jest.requireMock('@/hooks/useAdmin') as typeof import('@/hooks/useAdmin');
+    await act(async () => {
+      await refreshProfile();
+    });
+    expect(getUserProfile).not.toHaveBeenCalled();
+    expect(result.current.user).toBeNull();
+  });
 });

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -110,6 +110,9 @@ export default function AccountPage() {
       // Optionally refetch to reflect saved changes in UI
       const refreshed = await getUserProfile(uid);
       setForm(refreshed || form);
+      // Refresh the shared useAdmin store so RegistrationGate doesn't bounce back to /join.
+      const { refreshProfile } = await import('@/hooks/useAdmin');
+      await refreshProfile();
       setIsEditing(false);
       notify({ type: 'success', title: 'Saved', message: 'Account updated successfully.' });
     } catch (e: unknown) {
@@ -336,13 +339,13 @@ export default function AccountPage() {
                   </SelectBase>
                 </FieldGroup>
                 <FieldGroup label="LinkedIn URL" requiredHint="Optional">
-                  <InputBase placeholder="https://linkedin.com/in/..." value={form.linkedin || ""} onChange={(e) => setForm(f => ({ ...f, linkedin: e.target.value }))} />
+                  <InputBase placeholder="https://linkedin.com/in/..." inputMode="url" autoComplete="url" value={form.linkedin || ""} onChange={(e) => setForm(f => ({ ...f, linkedin: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="GitHub URL" requiredHint="Optional">
-                  <InputBase placeholder="https://github.com/username" value={form.github || ""} onChange={(e) => setForm(f => ({ ...f, github: e.target.value }))} />
+                  <InputBase placeholder="https://github.com/username" inputMode="url" autoComplete="url" value={form.github || ""} onChange={(e) => setForm(f => ({ ...f, github: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="Website" requiredHint="Optional">
-                  <InputBase placeholder="https://example.com" value={form.website || ""} onChange={(e) => setForm(f => ({ ...f, website: e.target.value }))} />
+                  <InputBase placeholder="https://example.com" inputMode="url" autoComplete="url" value={form.website || ""} onChange={(e) => setForm(f => ({ ...f, website: e.target.value }))} />
                 </FieldGroup>
               </div>
 

--- a/app/application/page.tsx
+++ b/app/application/page.tsx
@@ -1,21 +1,5 @@
-'use client';
+import { redirect } from "next/navigation";
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-
-export default function ApplicationPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    // Redirect to home page with hash
-    router.push('/#application');
-  }, [router]);
-
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a]">
-      <div className="text-center">
-        <p className="text-white/80">Redirecting to application section...</p>
-      </div>
-    </div>
-  );
-} 
+export default function Page() {
+  redirect("/apply/team");
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import React, { useEffect } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import LoginModal from '@/components/ui/LoginModal'
+import { useAdmin } from '@/hooks/useAdmin'
 import { updatePageMeta } from '@/utils/seo'
 
 export default function LoginPage() {
   const router = useRouter()
+  const { user, profile, profileLoading } = useAdmin()
 
   useEffect(() => {
     updatePageMeta('Sign In', 'Sign in to your UU AI Society account');
@@ -20,8 +23,20 @@ export default function LoginPage() {
     router.push(redirect && redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/account')
   }
 
+  // A provider account that never created a profile is signed out by the
+  // RegistrationGate off /join; point the user at account creation.
+  const needsAccount = user && !profileLoading && !(Boolean(profile?.isMember) && Boolean(profile?.privacyAcceptedAt))
+
   return (
     <div className="min-h-screen pt-24 pb-12 bg-gray-50 dark:bg-gray-900">
+      {needsAccount && (
+        <div className="max-w-xs mx-auto px-4 mb-4">
+          <p className="p-3 rounded-md border border-yellow-300 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-950 text-sm text-yellow-900 dark:text-yellow-200">
+            This account hasn&apos;t created a profile yet —{' '}
+            <Link href="/join" className="underline font-medium">create an account</Link> to continue.
+          </p>
+        </div>
+      )}
       <LoginModal after={after} />
     </div>
   )

--- a/components/auth/RegistrationGate.tsx
+++ b/components/auth/RegistrationGate.tsx
@@ -1,38 +1,29 @@
 "use client";
 
 import { useEffect } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useAdmin } from "@/hooks/useAdmin";
 
-// Client-side gate: if user is signed in but has not completed registration,
-// redirect them to /join except for public pages.
+// Client-side gate: a signed-in user who hasn't completed registration is only
+// allowed on /join (and the login/privacy pages). Navigating anywhere else signs them out.
 export default function RegistrationGate() {
-  const router = useRouter();
   const pathname = usePathname();
-  const { user, profile, profileLoading } = useAdmin();
+  const { user, profile, profileLoading, logout } = useAdmin();
 
   useEffect(() => {
-    // Allow public pages & auth pages without checks
-    const publicPaths = [
-      "/",
-      "/about",
-      "/contact",
-      "/events",
-      "/blog",
-      "/privacy",
-      "/login",
-      "/join",
-    ];
-    if (publicPaths.some((p) => pathname === p || pathname?.startsWith(p + "/"))) return;
-
-    if (!user) return; // anonymous visitors are allowed to public pages; private pages should also check auth separately
+    if (!user) return; // anonymous visitors browse freely
     if (profileLoading) return; // wait for the shared profile lookup so a complete profile isn't read as incomplete
 
     const completed = Boolean(profile?.isMember) && Boolean(profile?.privacyAcceptedAt);
-    if (!completed) {
-      router.push("/join");
-    }
-  }, [user, profile, profileLoading, pathname, router]);
+    if (completed) return;
+
+    // Half-registered: allow only the pages needed to finish or re-authenticate.
+    const allowedPaths = ["/join", "/login", "/privacy"];
+    if (allowedPaths.some((p) => pathname === p || pathname?.startsWith(p + "/"))) return;
+
+    // Navigated off /join without a complete account — sign them out.
+    logout();
+  }, [user, profile, profileLoading, pathname, logout]);
 
   return null;
 }

--- a/components/common/RagChat.tsx
+++ b/components/common/RagChat.tsx
@@ -381,7 +381,14 @@ export default function RagChat({ onRecommendations, onThinkingStart, placeholde
     await loadMoreChats();
   }, [loadMoreChats]);
 
+  const skipInitialFocusRef = useRef(true);
+
   useEffect(() => {
+    // Don't auto-focus on mount (pops the mobile keyboard); focus only after a user gesture flips `focused`.
+    if (skipInitialFocusRef.current) {
+      skipInitialFocusRef.current = false;
+      return;
+    }
     if (focused) {
       const el = containerRef.current?.querySelector('input');
       (el as HTMLInputElement | undefined)?.focus();
@@ -477,7 +484,7 @@ export default function RagChat({ onRecommendations, onThinkingStart, placeholde
                               handleDeleteChat(chat.id, e as unknown as React.MouseEvent);
                             }
                           }}
-                          className="opacity-0 group-hover:opacity-100 p-1 cursor-pointer hover:text-red-500 transition-opacity"
+                          className="opacity-60 sm:opacity-0 sm:group-hover:opacity-100 p-1 cursor-pointer hover:text-red-500 transition-opacity"
                         >
                           <Trash2 className="h-3 w-3" />
                         </span>

--- a/components/courses/CourseConnectionsFlow.tsx
+++ b/components/courses/CourseConnectionsFlow.tsx
@@ -385,7 +385,7 @@ export default function CourseConnectionsFlow({
       <div className={"border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-gray-50 dark:bg-gray-900 relative " + (isFull ? "w-full h-full" : "")}>
         <button
           onClick={() => setIsFull(f => !f)}
-          className="absolute top-2 right-2 z-10 px-2 py-1 text-xs rounded bg-gray-800 text-white hover:bg-gray-700 hover:shadow-lg transition-all"
+          className="absolute top-2 right-2 z-10 px-2 py-1 text-xs rounded bg-gray-800 text-white hover:bg-gray-700 hover:shadow-lg transition-all min-h-10 min-w-11"
         >
           {isFull ? "Exit Fullscreen" : "Fullscreen"}
         </button>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -138,7 +138,7 @@ export const Footer: React.FC = () => {
             </Link>
             <button
               onClick={scrollToTop}
-              className="size-9 grid place-items-center rounded-full border border-border text-foreground/50 hover:text-foreground hover:border-foreground/25 transition-colors duration-300 cursor-pointer"
+              className="size-11 grid place-items-center rounded-full border border-border text-foreground/50 hover:text-foreground hover:border-foreground/25 transition-colors duration-300 cursor-pointer"
               aria-label="Scroll to top"
             >
               <ArrowUp className="h-4 w-4" />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -196,7 +196,7 @@ export const Header: React.FC = () => {
               <button
                 ref={mobileButtonRef}
                 onClick={() => setIsMenuOpen((v) => !v)}
-                className="lg:hidden size-9 grid place-items-center rounded-sm text-current/70 hover:text-current hover:bg-current/[0.09] transition-colors cursor-pointer"
+                className="lg:hidden size-11 grid place-items-center rounded-sm text-current/70 hover:text-current hover:bg-current/[0.09] transition-colors cursor-pointer"
                 aria-expanded={isMenuOpen}
                 aria-controls="mobile-menu"
               >
@@ -211,7 +211,7 @@ export const Header: React.FC = () => {
             ref={mobileMenuRef}
             id="mobile-menu"
             inert={!isMenuOpen}
-            className={`lg:hidden overflow-hidden origin-top transition-all duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+            className={`lg:hidden overflow-x-hidden overflow-y-auto origin-top transition-all duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
               isMenuOpen ? 'max-h-[80vh] opacity-100' : 'max-h-0 opacity-0 pointer-events-none'
             }`}
           >

--- a/components/pages/BlogPage.tsx
+++ b/components/pages/BlogPage.tsx
@@ -184,7 +184,7 @@ const BlogPage: React.FC = () => {
 
       <div className="max-w-7xl mx-auto px-5 sm:px-8">
         {/* Articles toolbar: quiet expanding search + active filter */}
-        <div className="flex items-center justify-between gap-4 pt-5">
+        <div className="flex flex-wrap items-center justify-between gap-4 pt-5">
           {searchTerm && (
             <div className="flex items-center gap-2 min-w-0" aria-live="polite">
               <span className="text-sm text-muted-foreground whitespace-nowrap">Filtered by</span>

--- a/components/pages/BoardApplicationPage.tsx
+++ b/components/pages/BoardApplicationPage.tsx
@@ -235,7 +235,7 @@ export default function BoardApplicationPage() {
                         <div className="grid grid-cols-1 gap-4">
                           <Input label="Name" value={f?.name || ''} onChange={e => setField(r.id, 'name', e.target.value)} error={f?.errors?.name} fullWidth />
                           <Input label="Email" type="email" value={f?.email || ''} onChange={e => setField(r.id, 'email', e.target.value)} error={f?.errors?.email} fullWidth />
-                          <Input label="Phone" value={f?.phone || ''} onChange={e => setField(r.id, 'phone', e.target.value)} fullWidth />
+                          <Input label="Phone" type="tel" autoComplete="tel" value={f?.phone || ''} onChange={e => setField(r.id, 'phone', e.target.value)} fullWidth />
                         </div>
 
                         <div>

--- a/components/pages/JoinPage.tsx
+++ b/components/pages/JoinPage.tsx
@@ -4,8 +4,6 @@
 import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardHeader } from '@/components/ui/Card';
-import { HugeiconsIcon } from '@hugeicons/react';
-import { GithubIcon, GoogleIcon } from '@hugeicons/core-free-icons';
 import { updatePageMeta } from '@/utils/seo';
 import type { UserProfile } from '@/lib/firestore/users';
 import Link from 'next/link';
@@ -75,6 +73,9 @@ const JoinPage: React.FC = () => {
       }
       const refreshed = await getUserProfile(uid);
       setProfile(refreshed);
+      // Refresh the shared useAdmin store so RegistrationGate doesn't bounce the user back to /join.
+      const { refreshProfile } = await import('@/hooks/useAdmin');
+      await refreshProfile();
       notify({ type: 'success', title: 'Saved', message: 'Profile saved successfully.' });
       router.push('/account');
     } catch {
@@ -104,21 +105,6 @@ const JoinPage: React.FC = () => {
             </div>
           )
         )}
-
-        <Card>
-          <CardHeader>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Sign in or Create Account</h2>
-            <p className="text-gray-600 dark:text-gray-300 text-sm">Use one of the providers below. You can link more providers later in your account.</p>
-          </CardHeader>
-          <CardContent className="space-y-3 flex flex-col md:flex-col justify-center gap-2 pt-4 items-center max-w-md mx-auto">
-            <Button onClick={() => { void import('@/lib/firebase-client').then((m) => m.signInWithGooglePopup()); }} variant="outline">
-              <span className="flex items-center gap-2"><HugeiconsIcon icon={GoogleIcon} className="h-4 w-4"/> Continue with Google</span>
-            </Button>
-            <Button onClick={() => { void import('@/lib/firebase-client').then((m) => m.signInWithGithubPopup()); }} variant="outline">
-              <span className="flex items-center gap-2"><HugeiconsIcon icon={GithubIcon} className="h-4 w-4"/> Continue with GitHub</span>
-            </Button>
-          </CardContent>
-        </Card>
 
         {uid && (
           <Card>
@@ -154,13 +140,13 @@ const JoinPage: React.FC = () => {
                   </SelectBase>
                 </FieldGroup>
                 <FieldGroup label="LinkedIn URL" requiredHint="Optional">
-                  <InputBase maxLength={200} placeholder="https://linkedin.com/in/..." value={form.linkedin || ''} onChange={(e) => setForm(f => ({ ...f, linkedin: e.target.value }))} />
+                  <InputBase maxLength={200} placeholder="https://linkedin.com/in/..." inputMode="url" autoComplete="url" value={form.linkedin || ''} onChange={(e) => setForm(f => ({ ...f, linkedin: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="GitHub URL" requiredHint="Optional">
-                  <InputBase maxLength={200} placeholder="https://github.com/username" value={form.github || ''} onChange={(e) => setForm(f => ({ ...f, github: e.target.value }))} />
+                  <InputBase maxLength={200} placeholder="https://github.com/username" inputMode="url" autoComplete="url" value={form.github || ''} onChange={(e) => setForm(f => ({ ...f, github: e.target.value }))} />
                 </FieldGroup>
                 <FieldGroup label="Website" requiredHint="Optional">
-                  <InputBase maxLength={500} placeholder="https://example.com" value={form.website || ''} onChange={(e) => setForm(f => ({ ...f, website: e.target.value }))} />
+                  <InputBase maxLength={500} placeholder="https://example.com" inputMode="url" autoComplete="url" value={form.website || ''} onChange={(e) => setForm(f => ({ ...f, website: e.target.value }))} />
                 </FieldGroup>
               </div>
 

--- a/components/pages/admin/tabs/EventsTab.tsx
+++ b/components/pages/admin/tabs/EventsTab.tsx
@@ -186,7 +186,7 @@ const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onView
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-6">
+      <div className="flex flex-wrap justify-between items-center gap-3 mb-6">
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
           Events Management
         </h2>

--- a/components/ui/LoginModal.tsx
+++ b/components/ui/LoginModal.tsx
@@ -1,5 +1,10 @@
+'use client'
+
+import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { signInWithGooglePopup, signInWithGithubPopup } from '@/lib/firebase-client'
+import { getUserProfile } from '@/lib/firestore'
+import { useRouter } from 'next/navigation'
 
 import type { FC } from "react";
 import Link from "next/link";
@@ -12,6 +17,33 @@ interface LoginCardProps {
 }
 
 const LoginCard: FC<LoginCardProps> = ({ after }) => {
+    const router = useRouter();
+    const [error, setError] = useState<string | null>(null);
+
+    // A provider account that never created a profile is signed out by the
+    // RegistrationGate off /join; send it to /join to complete account creation.
+    const handleAuth = async (signIn: () => Promise<{ uid: string }>) => {
+        setError(null);
+        try {
+            const user = await signIn();
+            let completed = true;
+            try {
+                const profile = await getUserProfile(user.uid);
+                completed = Boolean(profile?.isMember) && Boolean(profile?.privacyAcceptedAt);
+            } catch (e) {
+                console.warn('Failed to load profile after sign-in:', e);
+            }
+            if (!completed) {
+                router.push('/join');
+                return;
+            }
+            after();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : 'Sign-in failed. Please try again.');
+            console.error('Sign-in failed:', e);
+        }
+    };
+
     return (
         <div className="min-h-screen pt-24 pb-12 bg-gray-50 dark:bg-gray-900">
             <div className="max-w-xs mx-auto px-4">
@@ -20,22 +52,27 @@ const LoginCard: FC<LoginCardProps> = ({ after }) => {
                     <p className="text-gray-600 dark:text-gray-300 text-sm text-center">Please login using one of the providers below to continue.</p>
                 </div>
                 <div className="space-y-3 gap-1 flex flex-col justify-center">
-                    <Button variant="outline" onClick={() => signInWithGooglePopup().then(after)}>
+                    <Button variant="outline" onClick={() => handleAuth(signInWithGooglePopup)}>
                         <span className="flex items-center gap-2"><HugeiconsIcon icon={GoogleIcon} className="h-4 w-4" /> Continue with Google</span>
                     </Button>
-                    <Button variant="outline" onClick={() => signInWithGithubPopup().then(after)}>
+                    <Button variant="outline" onClick={() => handleAuth(signInWithGithubPopup)}>
                         <span className="flex items-center gap-2"><HugeiconsIcon icon={GithubIcon} className="h-4 w-4" /> Continue with GitHub</span>
                     </Button>
                     {/* <Button onClick={() => signInWithMicrosoftPopup().then(after)}>
                         <span className="flex items-center gap-2"><MicrosoftIcon className="h-4 w-4" /> Continue with Microsoft</span>
                     </Button> */}
                 </div>
+                {error && (
+                    <p role="alert" className="mt-4 text-sm text-red-600 dark:text-red-400 text-center">
+                        {error}
+                    </p>
+                )}
                 <div className="text-center mt-8">
                     <p className="text-sm text-gray-600 dark:text-gray-400">
                         New here? <Link href="/join" className="underline">Create an account</Link>
                     </p>
                     <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                        <Link href="/privacy" className="underline">Privacy Policy</Link> 
+                        <Link href="/privacy" className="underline">Privacy Policy</Link>
                         {/* | <Link href="/terms" className="underline">Terms of Service</Link> */}
                     </p>
                 </div>

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -232,111 +232,124 @@ export const AppProvider: React.FC<{
 
   // Realtime Firestore listeners start after the main thread goes idle so they stay out of the critical network chain (LCP); SSR-seeded data already paints the content.
   useEffect(() => {
-    // Track the unsubscribe function for events so we can re-subscribe when admin status changes
-    let unsubscribeEvents: (() => void) | null = null;
-    let unsubscribeJobs: (() => void) | null = null;
-    let unsubscribeBoardPositions: (() => void) | null = null;
-    let unsubscribeBoardApplications: (() => void) | null = null;
-    let unsubscribeCampaigns: (() => void) | null = null;
-    let unsubscribeTeamApplications: (() => void) | null = null;
-    let unsubscribeBlogPosts: (() => void) | null = null;
-    let unsubscribeTeamMembers: (() => void) | null = null;
-    let unsubscribeFaqs: (() => void) | null = null;
+    // Listener refs are mutated async (dynamic import) so a late chunk from a superseded subscribe() can't clobber the active one.
+    const unsubscribeEvents: { current: (() => void) | null } = { current: null };
+    const unsubscribeJobs: { current: (() => void) | null } = { current: null };
+    const unsubscribeBoardPositions: { current: (() => void) | null } = { current: null };
+    const unsubscribeBoardApplications: { current: (() => void) | null } = { current: null };
+    const unsubscribeCampaigns: { current: (() => void) | null } = { current: null };
+    const unsubscribeTeamApplications: { current: (() => void) | null } = { current: null };
+    const unsubscribeBlogPosts: { current: (() => void) | null } = { current: null };
+    const unsubscribeTeamMembers: { current: (() => void) | null } = { current: null };
+    const unsubscribeFaqs: { current: (() => void) | null } = { current: null };
     let idTokenUnsub: (() => void) | null = null;
     let disposed = false;
+    // Bumped on every subscribe() so a listener from an older call drops itself instead of replacing the current one.
+    let subscriptionGeneration = 0;
 
     const subscribe = (includeUnpublished = false) => {
       // includeUnpublished: boolean indicates admin status
+      const gen = ++subscriptionGeneration;
+
+      // Subscribe once the chunk loads, dropping the listener if a newer subscribe() superseded us.
+      const attach = <T,>(
+        importPromise: Promise<T>,
+        ref: { current: (() => void) | null },
+        make: (mod: T) => () => void,
+      ) => {
+        void importPromise.then((mod) => {
+          if (disposed) return;
+          const unsub = make(mod);
+          if (gen !== subscriptionGeneration) {
+            try { unsub(); } catch { /* ignore */ }
+            return;
+          }
+          ref.current = unsub;
+        });
+      };
 
       // Unsubscribe previous
-      if (unsubscribeEvents) {
-        try { unsubscribeEvents(); } catch { /* ignore */ }
-        unsubscribeEvents = null;
+      if (unsubscribeEvents.current) {
+        try { unsubscribeEvents.current(); } catch { /* ignore */ }
+        unsubscribeEvents.current = null;
       }
-      void import('@/lib/firestore/events').then(({ subscribeToEvents }) => {
-        if (disposed) return;
-        unsubscribeEvents = subscribeToEvents((events) => {
+      attach(import('@/lib/firestore/events'), unsubscribeEvents, ({ subscribeToEvents }) =>
+        subscribeToEvents((events) => {
           dispatch({ type: 'SET_EVENTS', payload: events });
-        }, { includeUnpublished });
-      });
+        }, { includeUnpublished }),
+      );
 
-      if (unsubscribeJobs)  {
-        try { unsubscribeJobs(); } catch { /* ignore */ }
-        unsubscribeJobs = null;
+      if (unsubscribeJobs.current) {
+        try { unsubscribeJobs.current(); } catch { /* ignore */ }
+        unsubscribeJobs.current = null;
       }
-      void import('@/lib/firestore/jobs').then(({ subscribeToJobs }) => {
-        if (disposed) return;
-        unsubscribeJobs = subscribeToJobs((jobs) => {
+      attach(import('@/lib/firestore/jobs'), unsubscribeJobs, ({ subscribeToJobs }) =>
+        subscribeToJobs((jobs) => {
           dispatch({ type: 'SET_JOBS', payload: jobs });
-        }, { includeUnpublished });
-      });
+        }, { includeUnpublished }),
+      );
 
-      if (unsubscribeBoardPositions) {
-        try { unsubscribeBoardPositions(); } catch { /* ignore */ }
-        unsubscribeBoardPositions = null;
+      if (unsubscribeBoardPositions.current) {
+        try { unsubscribeBoardPositions.current(); } catch { /* ignore */ }
+        unsubscribeBoardPositions.current = null;
       }
-      void import('@/lib/firestore/board-positions').then(({ subscribeToPositions }) => {
-        if (disposed) return;
-        unsubscribeBoardPositions = subscribeToPositions((positions) => {
+      attach(import('@/lib/firestore/board-positions'), unsubscribeBoardPositions, ({ subscribeToPositions }) =>
+        subscribeToPositions((positions) => {
           dispatch({ type: 'SET_BOARDPOS', payload: positions });
-        });
-      });
+        }),
+      );
 
-      if (unsubscribeBoardApplications) {
-        try { unsubscribeBoardApplications(); } catch { /* ignore */ }
-        unsubscribeBoardApplications = null;
+      if (unsubscribeBoardApplications.current) {
+        try { unsubscribeBoardApplications.current(); } catch { /* ignore */ }
+        unsubscribeBoardApplications.current = null;
       }
       if (includeUnpublished) {
-        void import('@/lib/firestore/boardApplications').then(({ subscribeToBoardApplications }) => {
-          if (disposed) return;
-          unsubscribeBoardApplications = subscribeToBoardApplications((applications) => {
+        attach(import('@/lib/firestore/boardApplications'), unsubscribeBoardApplications, ({ subscribeToBoardApplications }) =>
+          subscribeToBoardApplications((applications) => {
             dispatch({ type: 'SET_APPLICANTS', payload: applications as Application[] });
-          });
-        });
+          }),
+        );
       } else {
         dispatch({ type: 'SET_APPLICANTS', payload: [] });
       }
 
       // Team applications: admin-only subscription
-      if (unsubscribeTeamApplications) {
-        try { unsubscribeTeamApplications(); } catch { /* ignore */ }
-        unsubscribeTeamApplications = null;
+      if (unsubscribeTeamApplications.current) {
+        try { unsubscribeTeamApplications.current(); } catch { /* ignore */ }
+        unsubscribeTeamApplications.current = null;
       }
       if (includeUnpublished) {
-        void import('@/lib/firestore/teamApplications').then(({ subscribeToTeamApplications }) => {
-          if (disposed) return;
-          unsubscribeTeamApplications = subscribeToTeamApplications((applications) => {
+        attach(import('@/lib/firestore/teamApplications'), unsubscribeTeamApplications, ({ subscribeToTeamApplications }) =>
+          subscribeToTeamApplications((applications) => {
             dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: applications as TeamApplication[] });
-          });
-        });
+          }),
+        );
       } else {
         dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: [] });
       }
 
       // Campaigns: public visitors only see open campaigns; admins see all (incl. drafts)
-      if (unsubscribeCampaigns) {
-        try { unsubscribeCampaigns(); } catch { /* ignore */ }
-        unsubscribeCampaigns = null;
+      if (unsubscribeCampaigns.current) {
+        try { unsubscribeCampaigns.current(); } catch { /* ignore */ }
+        unsubscribeCampaigns.current = null;
       }
-      void import('@/lib/firestore/applicationCampaigns').then(({ subscribeToCampaigns }) => {
-        if (disposed) return;
-        unsubscribeCampaigns = subscribeToCampaigns((campaigns) => {
+      attach(import('@/lib/firestore/applicationCampaigns'), unsubscribeCampaigns, ({ subscribeToCampaigns }) =>
+        subscribeToCampaigns((campaigns) => {
           dispatch({ type: 'SET_CAMPAIGNS', payload: campaigns });
           dispatch({ type: 'SET_CAMPAIGNS_LOADED', payload: true });
-        }, { includeAll: includeUnpublished });
-      });
+        }, { includeAll: includeUnpublished }),
+      );
 
       // Blog posts: public visitors see published posts; admins see all (incl. drafts)
-      if (unsubscribeBlogPosts) {
-        try { unsubscribeBlogPosts(); } catch { /* ignore */ }
-        unsubscribeBlogPosts = null;
+      if (unsubscribeBlogPosts.current) {
+        try { unsubscribeBlogPosts.current(); } catch { /* ignore */ }
+        unsubscribeBlogPosts.current = null;
       }
-      void import('@/lib/firestore/blog').then(({ subscribeToBlogPosts }) => {
-        if (disposed) return;
-        unsubscribeBlogPosts = subscribeToBlogPosts((posts) => {
+      attach(import('@/lib/firestore/blog'), unsubscribeBlogPosts, ({ subscribeToBlogPosts }) =>
+        subscribeToBlogPosts((posts) => {
           dispatch({ type: 'SET_BLOG_POSTS', payload: posts });
-        }, { includeUnpublished });
-      });
+        }, { includeUnpublished }),
+      );
     };
 
     // Returning visitors (cached identity) get realtime data immediately; anonymous visitors defer the firestore streams until after LCP / first interaction.
@@ -348,20 +361,20 @@ export const AppProvider: React.FC<{
         // Other static subscriptions that don't depend on auth
         void import('@/lib/firestore/team').then(({ subscribeToTeamMembers }) => {
           if (disposed) return;
-          unsubscribeTeamMembers = subscribeToTeamMembers((members) => {
+          unsubscribeTeamMembers.current = subscribeToTeamMembers((members) => {
             dispatch({ type: 'SET_TEAM_MEMBERS', payload: members });
           });
         });
 
         void import('@/lib/firestore/faqs').then(({ subscribeToFaqs }) => {
           if (disposed) return;
-          unsubscribeFaqs = subscribeToFaqs((faqs) => {
+          unsubscribeFaqs.current = subscribeToFaqs((faqs) => {
             dispatch({ type: 'SET_FAQS', payload: faqs });
           });
         });
 
-        // Listen for ID token changes to detect admin claim changes.
-        let currentAdminClaim: boolean | null = null;
+        // Listen for ID token changes; starts false so the first fire is a no-op for non-admins.
+        let currentAdminClaim: boolean | null = false;
         let authGeneration = 0;
         void Promise.all([import('firebase/auth'), import('@/lib/firebase-client')]).then(([{ onIdTokenChanged }, { auth }]) => {
           if (disposed) return;
@@ -394,32 +407,32 @@ export const AppProvider: React.FC<{
     // Cleanup subscriptions on unmount
     return () => {
       disposed = true;
-      if (unsubscribeEvents) {
-        try { unsubscribeEvents(); } catch { /* ignore */ }
+      if (unsubscribeEvents.current) {
+        try { unsubscribeEvents.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeJobs) {
-        try { unsubscribeJobs(); } catch { /* ignore */ }
+      if (unsubscribeJobs.current) {
+        try { unsubscribeJobs.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeBoardPositions) {
-        try { unsubscribeBoardPositions(); } catch { /* ignore */ }
+      if (unsubscribeBoardPositions.current) {
+        try { unsubscribeBoardPositions.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeBoardApplications) {
-        try { unsubscribeBoardApplications(); } catch { /* ignore */ }
+      if (unsubscribeBoardApplications.current) {
+        try { unsubscribeBoardApplications.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeCampaigns) {
-        try { unsubscribeCampaigns(); } catch { /* ignore */ }
+      if (unsubscribeCampaigns.current) {
+        try { unsubscribeCampaigns.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeTeamApplications) {
-        try { unsubscribeTeamApplications(); } catch { /* ignore */ }
+      if (unsubscribeTeamApplications.current) {
+        try { unsubscribeTeamApplications.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeBlogPosts) {
-        try { unsubscribeBlogPosts(); } catch { /* ignore */ }
+      if (unsubscribeBlogPosts.current) {
+        try { unsubscribeBlogPosts.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeTeamMembers) {
-        try { unsubscribeTeamMembers(); } catch { /* ignore */ }
+      if (unsubscribeTeamMembers.current) {
+        try { unsubscribeTeamMembers.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeFaqs) {
-        try { unsubscribeFaqs(); } catch { /* ignore */ }
+      if (unsubscribeFaqs.current) {
+        try { unsubscribeFaqs.current(); } catch { /* ignore */ }
       }
       if (idTokenUnsub) {
         try { idTokenUnsub(); } catch { /* ignore */ }

--- a/hooks/useAdmin.ts
+++ b/hooks/useAdmin.ts
@@ -52,6 +52,19 @@ const loadProfile = (uid: string): Promise<UserProfile | null> => {
   return request;
 };
 
+/** Re-read the signed-in user's profile and publish it to the store so dependent UI sees fresh data after a save. */
+export const refreshProfile = async (): Promise<void> => {
+  const uid = store.user?.uid;
+  if (!uid) return;
+  profileRequests.delete(uid);
+  const profile = await loadProfile(uid);
+  if (store.user?.uid !== uid) return;
+  const cached = store.cached
+    ? { ...store.cached, name: profile?.displayName || profile?.name || store.cached.name }
+    : null;
+  setStore({ profile, profileLoading: false, cached });
+};
+
 let started = false;
 
 const start = () => {
@@ -65,10 +78,15 @@ const start = () => {
     () => {
       void Promise.all([import('firebase/auth'), import('@/lib/firebase-client')]).then(
         ([{ onAuthStateChanged, getIdTokenResult }, { auth }]) => {
+          // Guard the async callback so a stale auth event can't clobber newer state (auth fires repeatedly on mobile).
+          let authGeneration = 0;
           onAuthStateChanged(auth, async (u) => {
+            const gen = ++authGeneration;
+
             if (!u) {
               profileRequests.clear();
               writeCache(null);
+              if (gen !== authGeneration) return;
               setStore({ user: null, loading: false, profileLoading: false, isAdmin: false, isSuperAdmin: false, claims: null, profile: null, cached: null });
               return;
             }
@@ -85,6 +103,8 @@ const start = () => {
             const isAdmin = Boolean(tokenClaims.admin);
             const isSuperAdmin = Boolean(tokenClaims.superAdmin);
 
+            if (gen !== authGeneration) return;
+
             setStore({
               user: u,
               loading: false,
@@ -96,7 +116,7 @@ const start = () => {
             });
 
             const profile = await loadProfile(u.uid);
-            if (auth.currentUser?.uid !== u.uid) return;
+            if (gen !== authGeneration) return;
 
             const name = profile?.displayName || profile?.name || u.displayName || null;
             const identity: CachedIdentity = { uid: u.uid, name, email: u.email, photoURL: u.photoURL, isAdmin };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -45,6 +45,7 @@ declare global {
   var __setMockTheme: ((theme: 'light' | 'dark') => void) | undefined;
   var __setMockParams: ((params: Record<string, string>) => void) | undefined;
   var __setAppState: ((state: Record<string, unknown> | null) => void) | undefined;
+  var __setAdminState: ((state: Record<string, unknown> | null) => void) | undefined;
 }
 
 beforeEach(() => {
@@ -129,16 +130,24 @@ global.__setMockParams = (params: Record<string, string>) => {
   Object.assign(mockParams, params);
 };
 
+let __mockAdminState: Record<string, unknown> | null = null;
+const __defaultAdminState = {
+  user: null,
+  loading: false,
+  profileLoading: false,
+  profile: null,
+  isAdmin: false,
+  isSuperAdmin: false,
+  claims: null,
+  signInWithGoogle: jest.fn(),
+  logout: jest.fn(),
+};
+global.__setAdminState = (state: Record<string, unknown> | null) => {
+  __mockAdminState = state;
+};
 jest.mock('@/hooks/useAdmin', () => ({
-  useAdmin: () => ({
-    user: null,
-    loading: false,
-    isAdmin: false,
-    isSuperAdmin: false,
-    claims: null,
-    signInWithGoogle: jest.fn(),
-    logout: jest.fn(),
-  }),
+  useAdmin: () => __mockAdminState || __defaultAdminState,
+  refreshProfile: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('next/image', () => {
@@ -223,6 +232,7 @@ jest.mock("@/lib/firestore", () => {
     recordAttendance: stub,
     getUsers: stub,
     getUserById: stub,
+    getUserProfile: stub,
     updateUser: stub,
     subscribeToAiChats: jest.fn(() => () => {}),
     addAiChat: stub,


### PR DESCRIPTION
## Summary

Resolves #64 (infinite reload loop on mobile) and fixes several related mobile + auth-flow issues found while investigating.

## Issue #64 — infinite reload loop on mobile

All three suspected root causes from the issue were fixed:

1. **`/application` dead hash redirect** — the page did a client-side `router.push('/#application')` to an anchor that no longer exists. Replaced with a clean server-side `redirect('/apply/team')`.
2. **AppContext auth re-subscription churn** (`contexts/AppContext.tsx`) — the first `onIdTokenChanged` fire always tore down and rebuilt every Firestore listener (visible churn on slow mobile connections). `currentAdminClaim` now starts `false` to match the initial public subscribe, and a `subscriptionGeneration` guard drops listeners that resolve late from a superseded subscribe call (was leaking listeners).
3. **`useAdmin` stale auth callbacks** (`hooks/useAdmin.ts`) — added an `authGeneration` guard so a stale auth event resolving after a newer one (or sign-out) can't re-assert an old user, which caused store flicker and repeated gate navigations.

## Auth-flow hardening

- **RegistrationGate** (`components/auth/RegistrationGate.tsx`) — signed-in users who haven't completed registration are now **auto-logged out** whenever they navigate off `/join`, `/login` or `/privacy`, instead of just being redirected (which previously let half-registered users reach `/account` and browse). Also fixed a stale-guard regression that made `/account` reachable after the first redirect.
- **LoginModal** (`components/ui/LoginModal.tsx`) — after a successful Google/GitHub sign-in with an account that has no complete profile, the user is now redirected to `/join` to finish account creation (previously they were silently signed out on the next page). Sign-in failures now show a visible error instead of failing silently.
- **`/login` page** — shows a "create an account" notice for signed-in users without a complete profile.
- **`refreshProfile`** exported from `useAdmin` and called after profile saves (`JoinPage`, `/account`) so the gate immediately sees the completed profile instead of bouncing users back to `/join`.
- Removed the "Sign in or Create Account" card from `/join` (sign-in now happens at `/login` / via LoginModal).

## Other mobile fixes

- **Header** — hamburger target enlarged to 44px; mobile menu now scrolls (`overflow-y-auto`) so admins on short phones can reach Logout/Admin (was clipped).
- **Footer** — scroll-to-top target enlarged to 44px.
- **RagChat** (`/explore`) — no longer auto-focuses the input on page load (pops the keyboard on mobile); the delete-chat control is visible on touch devices instead of hover-only (and invisible-but-clickable).
- **BoardApplicationPage** — phone field now `type="tel"`.
- **BlogPage / EventsTab** — toolbars wrap on narrow viewports (no horizontal overflow).
- **CourseConnectionsFlow** — fullscreen toggle meets touch-target size.
- **Account/Join URL fields** — `inputMode="url"` + `autoComplete` so mobile shows the URL keyboard.

## Tests

- New tests for the `/application` redirect, AppContext no-op non-admin first fire, `useAdmin` stale-auth guard + `refreshProfile`, RegistrationGate logout behavior, LoginModal `/join` redirect + error display, `/login` notice.
- 1015 unit tests + 162 integration tests pass; `npm run lint` and `npx tsc --noEmit` clean.
- Verified on a 390px mobile viewport: all public routes load, settle, and have no horizontal overflow or console errors.