### PR TITLE
Redesign Admin Dashboard (sidebar shell, per-tab data, design-system harmonization)

### DIFF
--- a/__tests__/app/api/mcp-server.test.ts
+++ b/__tests__/app/api/mcp-server.test.ts
@@ -45,8 +45,6 @@ const seed: PublicSeed = {
     { id: 't1', name: 'Ada', position: 'Board', email: 'ada@uuais.com', personalEmail: 'ada@personal.com', notes: 'internal' } as never,
     { id: 't2', name: 'Drafty', position: 'Member', published: false } as never,
   ],
-  boardPositions: [{ id: 'b1', title: 'Treasurer' } as never],
-  campaigns: [{ id: 'c1', title: 'Fall 2026' } as never],
 }
 
 async function mcpPost(message: Record<string, unknown>): Promise<Response> {

--- a/__tests__/app/pages/board-application-page.test.tsx
+++ b/__tests__/app/pages/board-application-page.test.tsx
@@ -34,25 +34,22 @@ describe('BoardApplicationPage', () => {
 
   it('renders empty state when no board positions', () => {
     mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    global.__setCollectionData?.({ subscribeToPositions: { data: [], loaded: true } })
     render(<BoardApplicationPage />)
     expect(screen.getByText('Open Positions')).toBeInTheDocument()
   })
 
   it('renders board position listing', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, boardPositions: [samplePosition] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    global.__setCollectionData?.({ subscribeToPositions: { data: [samplePosition], loaded: true } })
     render(<BoardApplicationPage />)
     expect(screen.getByText('Chairperson 2026')).toBeInTheDocument()
     expect(screen.getByText(/Deadline: 2026-05-10/)).toBeInTheDocument()
   })
 
   it('reveals application form on clicking Show details', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, boardPositions: [samplePosition] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    global.__setCollectionData?.({ subscribeToPositions: { data: [samplePosition], loaded: true } })
     render(<BoardApplicationPage />)
     fireEvent.click(screen.getByText('Show details'))
     expect(screen.getByText(/Lead the board/)).toBeInTheDocument()
@@ -60,10 +57,8 @@ describe('BoardApplicationPage', () => {
   })
 
   it('hides application form on clicking Hide details', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, boardPositions: [samplePosition] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    global.__setCollectionData?.({ subscribeToPositions: { data: [samplePosition], loaded: true } })
     render(<BoardApplicationPage />)
     fireEvent.click(screen.getByText('Show details'))
     expect(screen.getByText('Submit application')).toBeInTheDocument()
@@ -79,10 +74,8 @@ describe('BoardApplicationPage', () => {
       description: 'Lead the board and represent the society.',
     }
 
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, boardPositions: [positionWithSubmitted] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    global.__setCollectionData?.({ subscribeToPositions: { data: [positionWithSubmitted], loaded: true } })
     render(<BoardApplicationPage />)
     fireEvent.click(screen.getByText('Show details'))
     expect(screen.getByText(/Lead the board/)).toBeInTheDocument()

--- a/__tests__/app/pages/board-application-page.test.tsx
+++ b/__tests__/app/pages/board-application-page.test.tsx
@@ -81,4 +81,13 @@ describe('BoardApplicationPage', () => {
     expect(screen.getByText(/Lead the board/)).toBeInTheDocument()
     expect(screen.getByText('Submit application')).toBeInTheDocument()
   })
+
+  it('does not crash when submitting an untouched form after positions load async', () => {
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    global.__setCollectionData?.({ subscribeToPositions: { data: [samplePosition], loaded: true } })
+    render(<BoardApplicationPage />)
+    fireEvent.click(screen.getByText('Show details'))
+    // Submit immediately without touching any field — must not throw a TypeError.
+    expect(() => fireEvent.click(screen.getByText('Submit application'))).not.toThrow()
+  })
 })

--- a/__tests__/app/pages/team-application-page.test.tsx
+++ b/__tests__/app/pages/team-application-page.test.tsx
@@ -9,6 +9,11 @@ const mockNotify = jest.fn()
 const mockSubscribeToCampaignQuestions = jest.fn(() => jest.fn())
 let mockAuthUser: unknown = null
 
+function mockCampaigns(campaigns: unknown[], loaded = true) {
+  mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+  global.__setCollectionData?.({ subscribeOpenCampaigns: { data: campaigns, loaded } })
+}
+
 const mockRefreshSessionCookie = jest.fn(async () => {
   const token = mockAuthUser && typeof (mockAuthUser as { getIdToken?: unknown }).getIdToken === 'function'
     ? await (mockAuthUser as { getIdToken: (f: boolean) => Promise<string> }).getIdToken(true)
@@ -76,29 +81,20 @@ describe('TeamApplicationPage', () => {
   })
 
   it('shows loading state when no campaigns', () => {
-    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() })
+    mockCampaigns([], false)
     render(<TeamApplicationPage />)
     expect(screen.getByText('Loading campaigns…')).toBeInTheDocument()
   })
 
   it('shows no active campaigns message when only closed/draft campaigns exist', () => {
-    mockUseApp.mockReturnValue({
-      state: {
-        ...defaultAppState,
-        campaignsLoaded: true,
-        campaigns: [{ ...sampleCampaign, status: 'closed' }],
-      },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([{ ...sampleCampaign, status: 'closed' }], true)
     render(<TeamApplicationPage />)
     expect(screen.getByText('No active campaigns')).toBeInTheDocument()
   })
 
   it('renders hero with campaign title and overview', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     expect(screen.getByText('Spring 2026 Recruitment')).toBeInTheDocument()
     expect(screen.getByText(/We are looking for passionate students/)).toBeInTheDocument()
@@ -106,10 +102,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('shows team cards from campaign teams', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     expect(screen.getByText('IT')).toBeInTheDocument()
     expect(screen.getByText('Development')).toBeInTheDocument()
@@ -130,10 +124,7 @@ describe('TeamApplicationPage', () => {
         ...sampleCampaign.roles.slice(1),
       ],
     }
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [richCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([richCampaign])
     render(<TeamApplicationPage />)
     // Team description renders paragraphs and bullet points
     expect(screen.getByText('We keep the infra running.')).toBeInTheDocument()
@@ -154,10 +145,7 @@ describe('TeamApplicationPage', () => {
         { id: 'growth_member', teamId: 'growth', title: 'Growth Member', status: 'open', order: 2 },
       ],
     }
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [multiRoleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([multiRoleCampaign])
     render(<TeamApplicationPage />)
 
     expect(screen.getByText('IT Member')).toBeInTheDocument()
@@ -170,10 +158,8 @@ describe('TeamApplicationPage', () => {
   it('clamps overflowing descriptions and expands/collapses them on toggle', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 200 })
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 50 })
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
 
     const showMore = screen.getAllByRole('button', { name: /Show more/i })
@@ -188,10 +174,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('navigates to profile step on Continue click', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     // "Your Profile" appears in step-nav as well as h2; match the h2 heading specifically
@@ -199,10 +183,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('shows team selection step heading after navigating to step 4', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     // Step 0 -> 1 (Overview -> Profile)
     fireEvent.click(screen.getByText('Continue'))
@@ -222,10 +204,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('renders review step after completing all steps', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
@@ -242,10 +222,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('renders the custom-interest row as a text field without a dead checkbox', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
@@ -263,10 +241,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('filters the programme list as you type and selects with Enter', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
 
@@ -286,10 +262,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('commits free text when no programme matches', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
 
@@ -307,10 +281,7 @@ describe('TeamApplicationPage', () => {
       ...sampleCampaign,
       enabledStandardFields: ['name', 'email'],
     }
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [limitedCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([limitedCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     // Name/email still render, but disabled fields (LinkedIn, etc.) do not
@@ -327,46 +298,25 @@ describe('TeamApplicationPage', () => {
   })
 
   it('shows applications closed when the campaign deadline has passed', () => {
-    mockUseApp.mockReturnValue({
-      state: {
-        ...defaultAppState,
-        campaignsLoaded: true,
-        campaigns: [{ ...sampleCampaign, deadline: '2020-01-01' }],
-      },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([{ ...sampleCampaign, deadline: '2020-01-01' }], true)
     render(<TeamApplicationPage />)
     expect(screen.getByText('Applications Closed')).toBeInTheDocument()
     expect(screen.queryByText('Continue')).not.toBeInTheDocument()
   })
 
   it('shows "no roles open" screen when role selection is enabled but no roles are open', () => {
-    mockUseApp.mockReturnValue({
-      state: {
-        ...defaultAppState,
-        campaignsLoaded: true,
-        campaigns: [{ ...sampleCampaign, roles: [] }],
-      },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([{ ...sampleCampaign, roles: [] }], true)
     render(<TeamApplicationPage />)
     expect(screen.getByText('No roles are open right now')).toBeInTheDocument()
     expect(screen.queryByText('Continue')).not.toBeInTheDocument()
   })
 
   it('does not block the form when role selection is disabled even without roles', () => {
-    mockUseApp.mockReturnValue({
-      state: {
-        ...defaultAppState,
-        campaignsLoaded: true,
-        campaigns: [{
-          ...sampleCampaign,
-          roles: [],
-          enabledStandardFields: ['name', 'email', 'motivation', 'linkedin'],
-        }],
-      },
-      dispatch: jest.fn(),
-    })
+    mockCampaigns([{
+      ...sampleCampaign,
+      roles: [],
+      enabledStandardFields: ['name', 'email', 'motivation', 'linkedin'],
+    }], true)
     render(<TeamApplicationPage />)
     expect(screen.queryByText('No roles are open right now')).not.toBeInTheDocument()
     expect(screen.getByText('Continue')).toBeInTheDocument()
@@ -377,10 +327,8 @@ describe('TeamApplicationPage', () => {
       cb([{ id: 'q1', question: 'Why do you want to join?', required: true, type: 'textarea' }])
       return jest.fn()
     })
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
@@ -394,10 +342,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('explains why Continue is blocked with an actionable hint', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     // No name yet — the hint names the missing field
@@ -408,10 +354,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('explains why Submit is blocked until the confirmation is ticked', () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
@@ -442,10 +386,8 @@ describe('TeamApplicationPage', () => {
       uid: 'user-1',
       roleRanking: [{ roleId: 'it_member', teamId: 'it' }],
     })
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
 
     expect(await screen.findByText('Already Applied!')).toBeInTheDocument()
@@ -464,13 +406,7 @@ describe('TeamApplicationPage', () => {
     }
     mockGetTeamApplicationByUid.mockResolvedValue(null)
 
-    // Mutable so we can simulate the Firestore subscription reporting the new app mid-submit.
-    const stateRef = {
-      ...defaultAppState,
-      campaigns: [sampleCampaign],
-      teamApplications: [],
-    }
-    mockUseApp.mockReturnValue({ state: stateRef, dispatch: jest.fn() })
+    mockCampaigns([sampleCampaign])
 
     // Deferred fetch so we control when the submit response arrives
     let resolveFetch: (v: { ok: boolean; json: () => Promise<unknown> }) => void
@@ -500,15 +436,6 @@ describe('TeamApplicationPage', () => {
     fireEvent.click(screen.getByLabelText(/I confirm the information above is accurate/i))
     fireEvent.click(screen.getByRole('button', { name: /Submit application/i }))
 
-    // Firestore subscription reports the new application mid-flight
-    stateRef.teamApplications = [{
-      id: 'app-1',
-      campaignId: 'spring2026',
-      name: 'Alex',
-      email: 'alex@test.com',
-      emailNormalized: 'alex@test.com',
-      uid: 'user-1',
-    }]
     rerender(<TeamApplicationPage />)
 
     expect(screen.queryByText('Already Applied!')).not.toBeInTheDocument()
@@ -528,10 +455,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('persists a draft to localStorage as the user fills the form', async () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     fireEvent.click(screen.getByText('Continue'))
     fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: 'Alex' } })
@@ -549,10 +474,8 @@ describe('TeamApplicationPage', () => {
   })
 
   it('does not create a draft on a fresh page visit', async () => {
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
     await new Promise((r) => setTimeout(r, 450))
     const keys = Object.keys(localStorage).filter((k) => k.startsWith('teamApplicationDraft'))
@@ -563,10 +486,8 @@ describe('TeamApplicationPage', () => {
     localStorage.setItem('teamApplicationDraft:spring2026:anon', JSON.stringify({
       name: 'Alex', email: 'alex@test.com', step: 1, interests: [], roleRanking: [],
     }))
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
     render(<TeamApplicationPage />)
 
     await waitFor(() => expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ title: 'Draft restored' })))
@@ -579,10 +500,8 @@ describe('TeamApplicationPage', () => {
     localStorage.setItem('teamApplicationDraft:spring2026:user-1', JSON.stringify({
       name: 'Alex', email: 'alex@test.com', step: 4, interests: [], roleRanking: [],
     }))
-    mockUseApp.mockReturnValue({
-      state: { ...defaultAppState, campaigns: [sampleCampaign] },
-      dispatch: jest.fn(),
-    })
+    mockUseApp.mockReturnValue({ state: defaultAppState, dispatch: jest.fn() });
+mockCampaigns([sampleCampaign])
 
     const fetchMock = jest.fn((url: string) =>
       url === '/api/login'

--- a/__tests__/components/admin/admin-dashboard-tab-restore.test.tsx
+++ b/__tests__/components/admin/admin-dashboard-tab-restore.test.tsx
@@ -38,16 +38,16 @@ describe('AdminDashboard tab restore', () => {
     window.history.replaceState(null, '', '/admin?tab=blog')
     render(<AdminDashboard />)
 
-    expect(screen.getByText('Blog Management')).toBeInTheDocument()
-    expect(screen.queryByText('Events Management')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Blog' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { level: 2, name: 'Events' })).not.toBeInTheDocument()
   })
 
   it('restores the tab from ?tab= on a non-default tab', () => {
     window.history.replaceState(null, '', '/admin?tab=analytics')
     render(<AdminDashboard />)
 
-    expect(screen.getAllByText('Analytics').length).toBeGreaterThan(0)
-    expect(screen.queryByText('Events Management')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('heading', { level: 2, name: 'Analytics' }).length).toBeGreaterThan(0)
+    expect(screen.queryAllByRole('heading', { level: 2, name: 'Events' }).length).toBe(0)
   })
 
   it('falls back to localStorage when no ?tab= is present', () => {
@@ -55,7 +55,7 @@ describe('AdminDashboard tab restore', () => {
     window.history.replaceState(null, '', '/admin')
     render(<AdminDashboard />)
 
-    expect(screen.getByText('Jobs Management')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Jobs' })).toBeInTheDocument()
   })
 
   it('keeps the ?tab= param across a StrictMode double-mount (dev refresh)', () => {
@@ -66,7 +66,7 @@ describe('AdminDashboard tab restore', () => {
       </StrictMode>
     )
 
-    expect(screen.getByText('Blog Management')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Blog' })).toBeInTheDocument()
     expect(new URL(window.location.href).searchParams.get('tab')).toBe('blog')
     expect(localStorage.getItem('adminDashboardTab')).toBe('blog')
 
@@ -82,7 +82,7 @@ describe('AdminDashboard tab restore', () => {
       </StrictMode>
     )
 
-    expect(screen.getByText('Blog Management')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Blog' })).toBeInTheDocument()
     expect(new URL(window.location.href).searchParams.get('tab')).toBe('blog')
   })
 })

--- a/__tests__/components/admin/admin-dashboard-tab-restore.test.tsx
+++ b/__tests__/components/admin/admin-dashboard-tab-restore.test.tsx
@@ -50,6 +50,33 @@ describe('AdminDashboard tab restore', () => {
     expect(screen.queryAllByRole('heading', { level: 2, name: 'Events' }).length).toBe(0)
   })
 
+  it('restores the analytics sub-tab from ?tab=&sub= deep link', () => {
+    window.history.replaceState(null, '', '/admin?tab=analytics&sub=firebase')
+    render(<AdminDashboard />)
+
+    const firebaseSub = screen.getByRole('button', { name: 'Firebase' })
+    expect(firebaseSub).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('heading', { level: 2, name: 'Analytics' })).toBeInTheDocument()
+  })
+
+  it('restores the blog sub-tab from ?tab=&sub= deep link', () => {
+    window.history.replaceState(null, '', '/admin?tab=blog&sub=ai-settings')
+    render(<AdminDashboard />)
+
+    const aiSub = screen.getByRole('button', { name: 'AI News Desk' })
+    expect(aiSub).toHaveAttribute('aria-current', 'page')
+    // The top-level Blog tab is active (not the Posts default).
+    expect(screen.queryByRole('button', { name: 'Posts' })).not.toHaveAttribute('aria-current', 'page')
+  })
+
+  it('defaults an unknown ?sub= value to the first sub-tab', () => {
+    window.history.replaceState(null, '', '/admin?tab=analytics&sub=nonsense')
+    render(<AdminDashboard />)
+
+    const summarySub = screen.getByRole('button', { name: 'Summary' })
+    expect(summarySub).toHaveAttribute('aria-current', 'page')
+  })
+
   it('falls back to localStorage when no ?tab= is present', () => {
     localStorage.setItem('adminDashboardTab', 'jobs')
     window.history.replaceState(null, '', '/admin')

--- a/__tests__/components/admin/applications-tab.test.tsx
+++ b/__tests__/components/admin/applications-tab.test.tsx
@@ -1,15 +1,38 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import ApplicationsTab from '@/components/pages/admin/tabs/ApplicationsTab'
 import type { ApplicationCampaign, TeamApplication } from '@/types'
 
+jest.mock('@/lib/firestore/applicationCampaigns', () => ({
+  // Method shorthand keeps fn.name stable so the useCollectionData mock can key its responses by subscription.
+  subscribeAllCampaigns() { return jest.fn(); },
+  subscribeToCampaigns() { return jest.fn(); },
+  addCampaign: jest.fn().mockResolvedValue('new-id'),
+  updateCampaign: jest.fn().mockResolvedValue(undefined),
+  deleteCampaign: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/lib/firestore/teamApplications', () => ({
+  subscribeToTeamApplications() { return jest.fn(); },
+  deleteTeamApplicationWithLimits: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/components/ui/Notifications', () => ({
+  useNotify: () => ({ notify: jest.fn() }),
+}))
+
 jest.mock('@/lib/firestore/campaignQuestions', () => ({
   subscribeToCampaignQuestions: jest.fn(() => jest.fn()),
+  getCampaignQuestions: jest.fn().mockResolvedValue([]),
+  deleteCampaignQuestionsByCampaign: jest.fn().mockResolvedValue(undefined),
 }))
 
 const mockExportZip = jest.fn()
 jest.mock('@/lib/exportApplications', () => ({
   exportApplicationsZip: (...args: unknown[]) => mockExportZip(...args),
 }))
+
+import { updateCampaign, deleteCampaign } from '@/lib/firestore/applicationCampaigns'
+import { deleteCampaignQuestionsByCampaign } from '@/lib/firestore/campaignQuestions'
 
 const sampleCampaign: ApplicationCampaign = {
   id: 'spring2026',
@@ -39,16 +62,13 @@ const sampleSubmission: TeamApplication = {
   createdAt: '2026-04-01',
 }
 
-const baseProps = (overrides: Partial<React.ComponentProps<typeof ApplicationsTab>> = {}) => ({
-  campaigns: [] as ApplicationCampaign[],
-  applications: [] as TeamApplication[],
-  onAddCampaign: jest.fn(),
-  onEditCampaign: jest.fn(),
-  onDeleteCampaign: jest.fn(),
-  onUpdateCampaignStatus: jest.fn(),
-  onDeleteApplication: jest.fn(),
-  ...overrides,
-})
+// Campaigns and applications are fetched by the tab itself; key the responses by subscription name so re-renders keep their data.
+function mockData(campaigns: ApplicationCampaign[], applications: TeamApplication[] = []) {
+  global.__setCollectionData?.({
+    subscribeAllCampaigns: { data: campaigns, loaded: true },
+    subscribeToTeamApplications: { data: applications, loaded: true },
+  })
+}
 
 describe('ApplicationsTab', () => {
   beforeEach(() => {
@@ -56,18 +76,21 @@ describe('ApplicationsTab', () => {
   })
 
   it('renders header and New campaign button', () => {
-    render(<ApplicationsTab {...baseProps()} />)
-    expect(screen.getByText('Application Campaigns')).toBeInTheDocument()
+    mockData([])
+    render(<ApplicationsTab />)
+    expect(screen.getByText('Applications')).toBeInTheDocument()
     expect(screen.getByText('New campaign')).toBeInTheDocument()
   })
 
   it('shows empty state when no campaigns match filter', () => {
-    render(<ApplicationsTab {...baseProps({ campaigns: [] })} />)
+    mockData([])
+    render(<ApplicationsTab />)
     expect(screen.getByText(/No campaigns with status/i)).toBeInTheDocument()
   })
 
   it('renders campaign cards with status badges and actions', () => {
-    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign] })} />)
+    mockData([sampleCampaign])
+    render(<ApplicationsTab />)
     expect(screen.getByText('Spring 2026 Recruitment')).toBeInTheDocument()
     // Status badge appears as Tag; filter tab button also says "Open" — match the badge (text-sm size on Tag).
     const openMatches = screen.getAllByText('Open')
@@ -76,10 +99,11 @@ describe('ApplicationsTab', () => {
   })
 
   it('filters by Open tab', () => {
-    render(<ApplicationsTab {...baseProps({ campaigns: [
+    mockData([
       sampleCampaign,
       { ...sampleCampaign, id: 'closed-one', status: 'closed', title: 'Closed Campaign' },
-    ] })} />)
+    ])
+    render(<ApplicationsTab />)
     // Click the "Open" filter tab (filter buttons have border-b-2 class inline)
     const openButtons = screen.getAllByRole('button', { name: /^Open/i })
     fireEvent.click(openButtons.find(b => b.tagName === 'BUTTON')!)
@@ -88,82 +112,76 @@ describe('ApplicationsTab', () => {
   })
 
   it('switches to submissions view on View submissions click', () => {
-    render(<ApplicationsTab {...baseProps({
-      campaigns: [sampleCampaign],
-      applications: [sampleSubmission],
-    })} />)
+    mockData([sampleCampaign], [sampleSubmission])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('View submissions'))
     expect(screen.getByText('Submissions: Spring 2026 Recruitment')).toBeInTheDocument()
     expect(screen.getByText('Alice Doe')).toBeInTheDocument()
   })
 
-  it('calls onAddCampaign when New campaign is clicked', () => {
-    const onAddCampaign = jest.fn()
-    render(<ApplicationsTab {...baseProps({ onAddCampaign })} />)
+  it('opens the campaign builder when New campaign is clicked', () => {
+    mockData([])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('New campaign'))
-    expect(onAddCampaign).toHaveBeenCalled()
+    // The builder modal renders with a campaign title field
+    expect(screen.getByLabelText(/Campaign title/)).toBeInTheDocument()
   })
 
-  it('calls onEditCampaign when Edit is clicked', () => {
-    const onEditCampaign = jest.fn()
-    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign], onEditCampaign })} />)
+  it('opens the campaign builder pre-filled when Edit is clicked', async () => {
+    mockData([sampleCampaign])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('Edit'))
-    expect(onEditCampaign).toHaveBeenCalledWith(sampleCampaign)
+    // Questions load async before the form renders
+    expect(await screen.findByLabelText(/Campaign title/)).toHaveValue('Spring 2026 Recruitment')
   })
 
-  it('opens confirm modal when delete campaign clicked and confirms delete', () => {
-    const onDeleteCampaign = jest.fn()
-    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign], onDeleteCampaign })} />)
+  it('opens confirm modal when delete campaign clicked and confirms delete', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true)
+    mockData([sampleCampaign])
+    render(<ApplicationsTab />)
     // Click the destructive delete button (Trash2 icon-only button)
     fireEvent.click(screen.getByRole('button', { name: /delete campaign/i }))
     expect(screen.getByText('Delete campaign?')).toBeInTheDocument()
     fireEvent.click(screen.getByText('Delete'))
-    expect(onDeleteCampaign).toHaveBeenCalledWith('spring2026')
+    await waitFor(() => expect(deleteCampaign).toHaveBeenCalledWith('spring2026'))
+    await waitFor(() => expect(deleteCampaignQuestionsByCampaign).toHaveBeenCalledWith('spring2026'))
   })
 
   it('toggles campaign status via the segmented control', () => {
-    const onUpdateCampaignStatus = jest.fn()
-    render(<ApplicationsTab {...baseProps({ campaigns: [sampleCampaign], onUpdateCampaignStatus })} />)
+    mockData([sampleCampaign])
+    render(<ApplicationsTab />)
     // The card's status toggle has a "Draft" button (the filter tab says "Draft 0")
     fireEvent.click(screen.getByRole('button', { name: 'Draft' }))
-    expect(onUpdateCampaignStatus).toHaveBeenCalledWith('spring2026', 'draft')
+    expect(updateCampaign).toHaveBeenCalledWith('spring2026', { status: 'draft' })
   })
 
   it('expands a submission to show motivation on click', () => {
-    render(<ApplicationsTab {...baseProps({
-      campaigns: [sampleCampaign],
-      applications: [sampleSubmission],
-    })} />)
+    mockData([sampleCampaign], [sampleSubmission])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('View submissions'))
     fireEvent.click(screen.getByText('Alice Doe'))
     expect(screen.getByText('I want to contribute.')).toBeInTheDocument()
   })
 
   it('Back button returns to campaigns view', () => {
-    render(<ApplicationsTab {...baseProps({
-      campaigns: [sampleCampaign],
-      applications: [sampleSubmission],
-    })} />)
+    mockData([sampleCampaign], [sampleSubmission])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('View submissions'))
     fireEvent.click(screen.getByText('Back to campaigns'))
-    expect(screen.getByText('Application Campaigns')).toBeInTheDocument()
+    expect(screen.getByText('Applications')).toBeInTheDocument()
   })
 
   it('renders an Export .zip button in the submissions view', () => {
-    render(<ApplicationsTab {...baseProps({
-      campaigns: [sampleCampaign],
-      applications: [sampleSubmission],
-    })} />)
+    mockData([sampleCampaign], [sampleSubmission])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('View submissions'))
     expect(screen.getByText('Export .zip')).toBeInTheDocument()
   })
 
   it('exports filtered submissions when Export .zip is clicked', async () => {
     mockExportZip.mockResolvedValue(undefined)
-    render(<ApplicationsTab {...baseProps({
-      campaigns: [sampleCampaign],
-      applications: [sampleSubmission],
-    })} />)
+    mockData([sampleCampaign], [sampleSubmission])
+    render(<ApplicationsTab />)
     fireEvent.click(screen.getByText('View submissions'))
     fireEvent.click(screen.getByText('Export .zip'))
     expect(mockExportZip).toHaveBeenCalledWith(expect.objectContaining({
@@ -192,10 +210,8 @@ describe('ApplicationsTab', () => {
     }
 
     it('renders ranked role tags for a roleRanking submission', () => {
-      render(<ApplicationsTab {...baseProps({
-        campaigns: [roleCampaign],
-        applications: [roleSubmission],
-      })} />)
+      mockData([roleCampaign], [roleSubmission])
+      render(<ApplicationsTab />)
       fireEvent.click(screen.getByText('View submissions'))
       // The hidden expanded detail also contains the ranked labels, so scope via getAllByText
       expect(screen.getAllByText('#1 IT Member').length).toBeGreaterThan(0)
@@ -203,28 +219,25 @@ describe('ApplicationsTab', () => {
     })
 
     it('falls back to team tags for a legacy teamRanking submission', () => {
-      render(<ApplicationsTab {...baseProps({
-        campaigns: [roleCampaign],
-        applications: [sampleSubmission],
-      })} />)
+      mockData([roleCampaign], [sampleSubmission])
+      render(<ApplicationsTab />)
       fireEvent.click(screen.getByText('View submissions'))
       expect(screen.getByText('#1 IT')).toBeInTheDocument()
       expect(screen.getByText('#2 Development')).toBeInTheDocument()
     })
 
     it('shows the role count on the campaign card', () => {
-      render(<ApplicationsTab {...baseProps({ campaigns: [roleCampaign] })} />)
+      mockData([roleCampaign])
+      render(<ApplicationsTab />)
       expect(screen.getByText('2 roles')).toBeInTheDocument()
     })
 
     it('filters submissions by a specific role', () => {
-      render(<ApplicationsTab {...baseProps({
-        campaigns: [roleCampaign],
-        applications: [
-          roleSubmission,
-          { ...sampleSubmission, id: 'sub-legacy', teamRanking: ['it', 'development'] },
-        ],
-      })} />)
+      mockData([roleCampaign], [
+        roleSubmission,
+        { ...sampleSubmission, id: 'sub-legacy', teamRanking: ['it', 'development'] },
+      ])
+      render(<ApplicationsTab />)
       fireEvent.click(screen.getByText('View submissions'))
 
       // Role options are labelled "<Team> · <Role>"
@@ -235,10 +248,8 @@ describe('ApplicationsTab', () => {
 
     it('filters submissions by legacy team id when campaign has no roles', () => {
       const legacySubmission = { ...sampleSubmission, id: 'sub-legacy', teamRanking: ['it', 'development'] }
-      render(<ApplicationsTab {...baseProps({
-        campaigns: [sampleCampaign],
-        applications: [roleSubmission, legacySubmission],
-      })} />)
+      mockData([sampleCampaign], [roleSubmission, legacySubmission])
+      render(<ApplicationsTab />)
       fireEvent.click(screen.getByText('View submissions'))
 
       // No roles -> dropdown lists teams; both roleRanking and legacy submissions match "development"
@@ -248,10 +259,8 @@ describe('ApplicationsTab', () => {
     })
 
     it('expands a submission to show role preferences and proposed role', () => {
-      render(<ApplicationsTab {...baseProps({
-        campaigns: [roleCampaign],
-        applications: [roleSubmission],
-      })} />)
+      mockData([roleCampaign], [roleSubmission])
+      render(<ApplicationsTab />)
       fireEvent.click(screen.getByText('View submissions'))
       fireEvent.click(screen.getByText('Alice Doe'))
 

--- a/__tests__/components/admin/blog-ai-settings-tab.test.tsx
+++ b/__tests__/components/admin/blog-ai-settings-tab.test.tsx
@@ -66,7 +66,7 @@ describe('BlogAISettingsTab', () => {
   it('loads and renders the saved settings', async () => {
     mockGet.mockResolvedValue(settings)
     render(<BlogAISettingsTab />)
-    expect(await screen.findByText('AI News Desk Settings')).toBeInTheDocument()
+    expect(await screen.findByText('AI News Desk')).toBeInTheDocument()
     expect(screen.getByDisplayValue('openai/gpt-4o-mini')).toBeInTheDocument()
     expect(screen.getByDisplayValue('You write for students.')).toBeInTheDocument()
     expect(screen.getByDisplayValue(/OpenAI News\|https:\/\/openai\.com\/news\/rss\.xml/)).toBeInTheDocument()
@@ -78,7 +78,7 @@ describe('BlogAISettingsTab', () => {
     mockGet.mockResolvedValue(settings)
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true)
     render(<BlogAISettingsTab />)
-    await screen.findByText('AI News Desk Settings')
+    await screen.findByText('AI News Desk')
     fireEvent.click(screen.getByText('Reset to Defaults'))
     expect(screen.getByDisplayValue('deepseek/deepseek-v4-flash-0731')).toBeInTheDocument()
     expect(screen.getByDisplayValue(/DeepMind\|https:\/\/deepmind\.google\/blog\/rss\.xml/)).toBeInTheDocument()
@@ -90,7 +90,7 @@ describe('BlogAISettingsTab', () => {
     mockGet.mockResolvedValue(settings)
     mockUpdate.mockResolvedValue(undefined)
     render(<BlogAISettingsTab />)
-    await screen.findByText('AI News Desk Settings')
+    await screen.findByText('AI News Desk')
     fireEvent.click(screen.getByText('Save Changes'))
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith(
@@ -103,7 +103,7 @@ describe('BlogAISettingsTab', () => {
   it('disables save for non-super-admins', async () => {
     mockGet.mockResolvedValue(settings)
     render(<BlogAISettingsTab />)
-    await screen.findByText('AI News Desk Settings')
+    await screen.findByText('AI News Desk')
     expect(screen.getByText('Save Changes')).toBeDisabled()
   })
 
@@ -156,7 +156,7 @@ describe('BlogAISettingsTab', () => {
     mockGetCovered.mockResolvedValue([])
     mockAddUsed.mockResolvedValue([])
     render(<BlogAISettingsTab />)
-    await screen.findByText('AI News Desk Settings')
+    await screen.findByText('AI News Desk')
 
     fireEvent.change(screen.getByLabelText('URL to mark as used'), { target: { value: 'https://example.com/ai' } })
     fireEvent.click(screen.getByRole('button', { name: 'Mark URL as used' }))

--- a/__tests__/components/layout/header.test.tsx
+++ b/__tests__/components/layout/header.test.tsx
@@ -10,6 +10,11 @@ jest.mock('@/hooks/useAdmin', () => ({
   useAdmin: () => mockUseAdmin(),
 }))
 
+const mockUseOpenCampaigns = jest.fn()
+jest.mock('@/lib/firestore/useOpenCampaigns', () => ({
+  useOpenCampaigns: () => mockUseOpenCampaigns(),
+}))
+
 const g = global as { __mockPathname?: string }
 
 function mockAdminState(overrides: Record<string, unknown> = {}) {
@@ -32,6 +37,7 @@ describe('Header', () => {
     g.__mockPathname = '/events'
     mockAdminState()
     global.__setAppState?.(null)
+    mockUseOpenCampaigns.mockReturnValue({ campaigns: [], loaded: false })
   })
 
   describe('navigation links', () => {
@@ -91,29 +97,25 @@ describe('Header', () => {
 
   describe('Apply CTA visibility', () => {
     it('hides Apply when campaigns are loaded and none are open', () => {
-      global.__setCollectionData?.({
-        subscribeOpenCampaigns: {
-          data: [{ id: 'c1', status: 'closed', title: 'Closed', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
-          loaded: true,
-        },
+      mockUseOpenCampaigns.mockReturnValue({
+        campaigns: [{ id: 'c1', status: 'closed', title: 'Closed', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
+        loaded: true,
       })
       render(<Header />)
       expect(screen.queryByRole('link', { name: 'Apply' })).not.toBeInTheDocument()
     })
 
     it('shows Apply when an open campaign exists', () => {
-      global.__setCollectionData?.({
-        subscribeOpenCampaigns: {
-          data: [{ id: 'c1', status: 'open', title: 'Open', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
-          loaded: true,
-        },
+      mockUseOpenCampaigns.mockReturnValue({
+        campaigns: [{ id: 'c1', status: 'open', title: 'Open', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
+        loaded: true,
       })
       render(<Header />)
       expect(screen.getAllByRole('link', { name: 'Apply' }).length).toBe(2)
     })
 
     it('shows Apply while campaigns are still loading', () => {
-      global.__setCollectionData?.({ subscribeOpenCampaigns: { data: [], loaded: false } })
+      mockUseOpenCampaigns.mockReturnValue({ campaigns: [], loaded: false })
       render(<Header />)
       expect(screen.getAllByRole('link', { name: 'Apply' }).length).toBe(2)
     })

--- a/__tests__/components/layout/header.test.tsx
+++ b/__tests__/components/layout/header.test.tsx
@@ -91,25 +91,29 @@ describe('Header', () => {
 
   describe('Apply CTA visibility', () => {
     it('hides Apply when campaigns are loaded and none are open', () => {
-      global.__setAppState?.({
-        campaigns: [{ id: 'c1', status: 'closed', title: 'Closed', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
-        campaignsLoaded: true,
+      global.__setCollectionData?.({
+        subscribeOpenCampaigns: {
+          data: [{ id: 'c1', status: 'closed', title: 'Closed', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
+          loaded: true,
+        },
       })
       render(<Header />)
       expect(screen.queryByRole('link', { name: 'Apply' })).not.toBeInTheDocument()
     })
 
     it('shows Apply when an open campaign exists', () => {
-      global.__setAppState?.({
-        campaigns: [{ id: 'c1', status: 'open', title: 'Open', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
-        campaignsLoaded: true,
+      global.__setCollectionData?.({
+        subscribeOpenCampaigns: {
+          data: [{ id: 'c1', status: 'open', title: 'Open', subtitle: '', description: '', deadline: '', teams: [], enabledStandardFields: [] }],
+          loaded: true,
+        },
       })
       render(<Header />)
       expect(screen.getAllByRole('link', { name: 'Apply' }).length).toBe(2)
     })
 
     it('shows Apply while campaigns are still loading', () => {
-      global.__setAppState?.(null)
+      global.__setCollectionData?.({ subscribeOpenCampaigns: { data: [], loaded: false } })
       render(<Header />)
       expect(screen.getAllByRole('link', { name: 'Apply' }).length).toBe(2)
     })

--- a/__tests__/contexts/AppContext.test.tsx
+++ b/__tests__/contexts/AppContext.test.tsx
@@ -49,33 +49,8 @@ jest.mock('@/lib/firestore/jobs', () => ({
   deleteJob: jest.fn(),
 }));
 
-jest.mock('@/lib/firestore/board-positions', () => ({
-  subscribeToPositions: jest.fn(() => mockUnsubscribe),
-  addPosition: jest.fn(),
-  updatePosition: jest.fn(),
-  deletePosition: jest.fn(),
-  movePosition: jest.fn(),
-}));
-
-jest.mock('@/lib/firestore/boardApplications', () => ({
-  subscribeToBoardApplications: jest.fn(() => mockUnsubscribe),
-  deleteBoardApplication: jest.fn(),
-}));
-
-jest.mock('@/lib/firestore/applicationCampaigns', () => ({
-  subscribeToCampaigns: jest.fn(() => mockUnsubscribe),
-  addCampaign: jest.fn(),
-  updateCampaign: jest.fn(),
-  deleteCampaign: jest.fn(),
-}));
-
 jest.mock('@/lib/firestore/campaignQuestions', () => ({
   deleteCampaignQuestionsByCampaign: jest.fn(),
-}));
-
-jest.mock('@/lib/firestore/teamApplications', () => ({
-  subscribeToTeamApplications: jest.fn(() => mockUnsubscribe),
-  deleteTeamApplication: jest.fn(),
 }));
 
 import { AppProvider, useApp } from '@/contexts/AppContext';
@@ -94,11 +69,6 @@ import {
 import {
   subscribeToJobs, addJob, updateJob, deleteJob,
 } from '@/lib/firestore/jobs';
-import {
-  subscribeToPositions, addPosition, updatePosition, deletePosition, movePosition,
-} from '@/lib/firestore/board-positions';
-import { deleteBoardApplication } from '@/lib/firestore/boardApplications';
-import { addCampaign } from '@/lib/firestore/applicationCampaigns';
 import { onIdTokenChanged } from 'firebase/auth';
 
 const mockEvent = { id: 'evt-1', title: 'Test Event', description: 'Desc', location: 'Loc', image: '', category: 'workshop' as const, status: 'upcoming' as const, registrationRequired: false, eventStartAt: '2026-01-01T00:00:00Z' };
@@ -106,8 +76,6 @@ const mockTeamMember = { id: 'tm-1', name: 'Alice', position: 'Dev' };
 const mockBlogPost = { id: 'bp-1', title: 'Post', excerpt: 'Excerpt', content: 'Content', author: 'Bob', date: '2026-01-01', image: '', tags: [], published: true };
 const mockFaq = { id: 'faq-1', question: 'Q?', answer: 'A!', category: 'general', order: 0, published: true };
 const mockJob = { id: 'job-1', type: 'job' as const, title: 'Engineer', company: 'Co', description: 'desc', published: true };
-const mockBoardPosition = { id: 'bp-1', title: 'Chair', short: 'CH', description: 'Lead', order: 1 };
-const mockApplication = { id: 'app-1', name: 'Alice', email: 'alice@example.com', role: 'Chair', status: 'pending' as const, submittedAt: '2026-01-01' };
 
 function renderApp() {
   return renderHook(() => useApp(), { wrapper: AppProvider as React.FC<{ children: React.ReactNode }> });
@@ -132,8 +100,6 @@ describe('AppContext', () => {
     expect(result.current.state.blogPosts).toEqual([]);
     expect(result.current.state.faqs).toEqual([]);
     expect(result.current.state.jobs).toEqual([]);
-    expect(result.current.state.boardPositions).toEqual([]);
-    expect(result.current.state.applicants).toEqual([]);
     expect(result.current.state.isLoading).toBe(false);
     expect(result.current.state.error).toBeNull();
   });
@@ -146,7 +112,6 @@ describe('AppContext', () => {
     expect(subscribeToBlogPosts).toHaveBeenCalledTimes(1);
     expect(subscribeToFaqs).toHaveBeenCalledTimes(1);
     expect(subscribeToJobs).toHaveBeenCalledTimes(1);
-    expect(subscribeToPositions).toHaveBeenCalledTimes(1);
     await waitFor(() => expect(onIdTokenChanged).toHaveBeenCalledTimes(1));
     expect(idTokenCallback).not.toBeNull();
   });
@@ -288,14 +253,6 @@ describe('AppContext', () => {
       expect(result.current.state.jobs).toEqual([mockJob]);
     });
 
-    it('SET_BOARDPOS', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ type: 'SET_BOARDPOS', payload: [mockBoardPosition] });
-      });
-      expect(result.current.state.boardPositions).toEqual([mockBoardPosition]);
-    });
-
     it('ADD_BLOG_POST regular action', async () => {
       const { result } = renderApp();
       await act(async () => {
@@ -387,45 +344,6 @@ describe('AppContext', () => {
         await result.current.dispatch({ type: 'DELETE_JOB', payload: mockJob.id });
       });
       expect(result.current.state.jobs).toEqual([]);
-    });
-
-    it('ADD_BOARDPOS regular action', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ type: 'ADD_BOARDPOS', payload: mockBoardPosition });
-      });
-      expect(result.current.state.boardPositions).toEqual([mockBoardPosition]);
-    });
-
-    it('UPDATE_BOARDPOS regular action', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ type: 'SET_BOARDPOS', payload: [mockBoardPosition] });
-      });
-      const updated = { ...mockBoardPosition, title: 'Updated Chair' };
-      await act(async () => {
-        await result.current.dispatch({ type: 'UPDATE_BOARDPOS', payload: updated });
-      });
-      expect(result.current.state.boardPositions).toEqual([updated]);
-    });
-
-    it('DELETE_BOARDPOS regular action', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ type: 'SET_BOARDPOS', payload: [mockBoardPosition] });
-      });
-      await act(async () => {
-        await result.current.dispatch({ type: 'DELETE_BOARDPOS', payload: mockBoardPosition.id });
-      });
-      expect(result.current.state.boardPositions).toEqual([]);
-    });
-
-    it('SET_APPLICANTS regular action', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ type: 'SET_APPLICANTS', payload: [mockApplication] });
-      });
-      expect(result.current.state.applicants).toEqual([mockApplication]);
     });
 
     it('resets loading to false after dispatch completes via finally block', async () => {
@@ -561,20 +479,6 @@ describe('AppContext', () => {
       expect(returned).toBe('new-job-id');
     });
 
-    it('ADD_CAMPAIGN calls addCampaign and returns the id (so custom questions can be saved)', async () => {
-      (addCampaign as jest.Mock).mockResolvedValue('new-campaign-id');
-      const { result } = renderApp();
-      const payload = {
-        title: 'Spring 2026', subtitle: 'Sub', description: 'Desc', deadline: '2026-03-01',
-        status: 'draft' as const, teams: ['it', 'development'],
-        teamInfo: { it: { name: 'IT' } },
-        enabledStandardFields: ['name', 'email', 'motivation'],
-      };
-      const returned = await act(async () => result.current.dispatch({ firestoreAction: 'ADD_CAMPAIGN', payload }));
-      expect(addCampaign).toHaveBeenCalledWith(payload);
-      expect(returned).toBe('new-campaign-id');
-    });
-
     it('UPDATE_JOB calls updateJob', async () => {
       const { result } = renderApp();
       await act(async () => {
@@ -591,42 +495,6 @@ describe('AppContext', () => {
       expect(deleteJob).toHaveBeenCalledWith('job-1');
     });
 
-    it('ADD_BOARDPOS calls addPosition', async () => {
-      const { result } = renderApp();
-      const payload = { title: 'Chair', short: 'CH', description: 'Lead' };
-      await act(async () => {
-        await result.current.dispatch({ firestoreAction: 'ADD_BOARDPOS', payload });
-      });
-      expect(addPosition).toHaveBeenCalledWith(payload);
-    });
-
-    it('MOVE_BOARDPOS calls movePosition with current state', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ type: 'SET_BOARDPOS', payload: [mockBoardPosition] });
-      });
-      await act(async () => {
-        await result.current.dispatch({ firestoreAction: 'MOVE_BOARDPOS', payload: { positionId: 'bp-1', direction: 'down' } });
-      });
-      expect(movePosition).toHaveBeenCalledWith([mockBoardPosition], 'bp-1', 'down');
-    });
-
-    it('DELETE_BOARDPOS calls deletePosition', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ firestoreAction: 'DELETE_BOARDPOS', payload: 'bp-1' });
-      });
-      expect(deletePosition).toHaveBeenCalledWith('bp-1');
-    });
-
-    it('DELETE_BOARD_APPLICATION calls deleteBoardApplication', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ firestoreAction: 'DELETE_BOARD_APPLICATION', payload: 'app-1' });
-      });
-      expect(deleteBoardApplication).toHaveBeenCalledWith('app-1');
-    });
-
     it('UPDATE_TEAM_MEMBER firestore calls updateTeamMember', async () => {
       const { result } = renderApp();
       await act(async () => {
@@ -641,14 +509,6 @@ describe('AppContext', () => {
         await result.current.dispatch({ firestoreAction: 'DELETE_TEAM_MEMBER', payload: 'tm-1' });
       });
       expect(deleteTeamMember).toHaveBeenCalledWith('tm-1');
-    });
-
-    it('UPDATE_BOARDPOS firestore calls updatePosition', async () => {
-      const { result } = renderApp();
-      await act(async () => {
-        await result.current.dispatch({ firestoreAction: 'UPDATE_BOARDPOS', payload: mockBoardPosition });
-      });
-      expect(updatePosition).toHaveBeenCalledWith(mockBoardPosition.id, mockBoardPosition);
     });
   });
 

--- a/__tests__/lib/mcp/uuais-data.test.ts
+++ b/__tests__/lib/mcp/uuais-data.test.ts
@@ -54,8 +54,6 @@ const seed: PublicSeed = {
   jobs: [],
   faqs: [{ id: 'f1', question: 'How do I join?', answer: 'Sign up on the site', category: 'general', order: 1, published: true } as never],
   teamMembers: [{ id: 't1', name: 'Ada Lovelace', position: 'Board member', teams: ['board'] } as never],
-  boardPositions: [],
-  campaigns: [],
 }
 
 const blogPosts: FakeDoc[] = [

--- a/__tests__/lib/use-collection-data.test.ts
+++ b/__tests__/lib/use-collection-data.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// jest.setup.ts mocks this module globally for component tests; unmock it here
+// so this unit test exercises the real hook.
+jest.unmock('@/lib/firestore/useCollectionData')
+
+import { useCollectionData } from '@/lib/firestore/useCollectionData'
+
+describe('useCollectionData', () => {
+  it('returns data and loaded from the subscription', async () => {
+    const subscribe = jest.fn((cb: (items: number[]) => void) => {
+      cb([1, 2, 3])
+      return jest.fn()
+    })
+
+    const { result } = renderHook(() => useCollectionData(subscribe, []))
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.data).toEqual([1, 2, 3])
+  })
+
+  it('treats a throwing subscribe as empty-but-loaded (no crash)', async () => {
+    const subscribe = jest.fn(() => {
+      throw new Error('INTERNAL ASSERTION FAILED')
+    })
+
+    const { result } = renderHook(() => useCollectionData(subscribe, []))
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.data).toEqual([])
+  })
+
+  it('swallows a throwing unsubscribe on unmount', () => {
+    const subscribe = jest.fn(() => () => {
+      throw new Error('INTERNAL ASSERTION FAILED')
+    })
+
+    expect(() => {
+      const { unmount } = renderHook(() => useCollectionData(subscribe, []))
+      act(() => unmount())
+    }).not.toThrow()
+  })
+
+  it('ignores late subscription updates after unmount', () => {
+    let emit: (items: number[]) => void = () => {}
+    const subscribe = jest.fn((cb: (items: number[]) => void) => {
+      emit = cb
+      return jest.fn()
+    })
+
+    const { unmount } = renderHook(() => useCollectionData(subscribe, []))
+    unmount()
+    expect(() => act(() => emit([9]))).not.toThrow()
+  })
+})

--- a/app/globals.css
+++ b/app/globals.css
@@ -84,6 +84,7 @@
 
 @layer base {
   :root {
+    color-scheme: light;
     --radius: 0.375rem;
 
     /* Warm paper, not pure white — gives glass something to tint against */
@@ -164,6 +165,7 @@
   }
 
   .dark {
+    color-scheme: dark;
     --background: oklch(0.155 0.012 265);
     --foreground: oklch(0.96 0.003 95);
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -6,10 +6,12 @@ import { usePathname } from 'next/navigation';
 import { Menu, X, ChevronDown } from 'lucide-react';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { useAdmin } from '@/hooks/useAdmin';
-import { useApp } from '@/contexts/AppContext';
 import { useEffect, useState, useRef } from 'react';
 import { Button } from '@/components/ui/Button';
 import { loginUrl } from '@/lib/login-redirect';
+import { useCollectionData } from '@/lib/firestore/useCollectionData';
+import { subscribeOpenCampaigns } from '@/lib/firestore/applicationCampaigns';
+import type { ApplicationCampaign } from '@/types';
 
 const navigation = [
   { name: 'Home', href: '/' },
@@ -33,7 +35,6 @@ const BetaBadge: React.FC = () => (
 );
 
 export const Header: React.FC = () => {
-  const { state } = useApp();
   const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isProjectsOpen, setIsProjectsOpen] = useState(false);
@@ -53,7 +54,8 @@ export const Header: React.FC = () => {
 
   // Hide the Apply CTA when no open application campaign exists (show it while
   // campaigns are still loading to avoid a flicker on first paint).
-  const showApply = !state.campaignsLoaded || state.campaigns.some((c) => c.status === 'open');
+  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeOpenCampaigns, []);
+  const showApply = !campaignsLoaded || campaigns.some((c) => c.status === 'open');
 
   // Rendered from the persisted identity so the name survives a reload instead
   // of blanking while Firebase re-resolves the session.

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -9,9 +9,7 @@ import { useAdmin } from '@/hooks/useAdmin';
 import { useEffect, useState, useRef } from 'react';
 import { Button } from '@/components/ui/Button';
 import { loginUrl } from '@/lib/login-redirect';
-import { useCollectionData } from '@/lib/firestore/useCollectionData';
-import { subscribeOpenCampaigns } from '@/lib/firestore/applicationCampaigns';
-import type { ApplicationCampaign } from '@/types';
+import { useOpenCampaigns } from '@/lib/firestore/useOpenCampaigns';
 
 const navigation = [
   { name: 'Home', href: '/' },
@@ -54,7 +52,7 @@ export const Header: React.FC = () => {
 
   // Hide the Apply CTA when no open application campaign exists (show it while
   // campaigns are still loading to avoid a flicker on first paint).
-  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeOpenCampaigns, []);
+  const { campaigns, loaded: campaignsLoaded } = useOpenCampaigns();
   const showApply = !campaignsLoaded || campaigns.some((c) => c.status === 'open');
 
   // Rendered from the persisted identity so the name survives a reload instead

--- a/components/pages/BoardApplicationPage.tsx
+++ b/components/pages/BoardApplicationPage.tsx
@@ -5,45 +5,14 @@ import { auth } from '@/lib/firebase-client';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Button } from '@/components/ui/Button';
-import { useApp } from "@/contexts/AppContext";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
+import { subscribeToPositions } from "@/lib/firestore/board-positions";
 
 const COVER_LETTER_MAX_CHARS = 3500;
 
 export default function BoardApplicationPage() {
-  const { state } = useApp();
-  const roles = state.boardPositions;
-  // const roles = [
-  //   { 
-  //     id: 'chairman2026', 
-  //     title: 'Chairman of the Board 2026', 
-  //     short: 'Deadline: 2026-05-10', 
-  //     description: 'Responsible for overall leadership, meeting facilitation, mentorship, and representing UU AI Society to internal and external stakeholders.' },
-  //   { 
-  //     id: 'vice-chairman2026', 
-  //     title: 'Vice Chairman of the Board 2026', 
-  //     short: 'Deadline: 2026-05-10', 
-  //     description: 'Second-highest management role, for technical coordination, decision-making and mentorship of the board members and members in UU AI Society.' },
-  //   { 
-  //     id: 'head-of-internal-it2026', 
-  //     title: 'Head of Internal IT 2026', 
-  //     short: 'Deadline: 2026-05-10', 
-  //     description: 'Management of IT services of UU AI Society, such as the website and technological assets.' },
-  //   { 
-  //     id: 'head-of-dev2026', 
-  //     title: 'Head of Development 2026', 
-  //     short: 'Deadline: 2026-05-10', 
-  //     description: 'Managing development, and a team of driven minds to develop ideas for tech-based projects built at UU AI Society.'},
-  //   { 
-  //     id: 'head-of-partnerships-and-events2026', 
-  //     title: 'Head of Partnerships & Events 2026', 
-  //     short: 'Deadline: 2026-05-10', 
-  //     description: 'As a Head of Partnerships & Events, you are in-charge of planning and coordinating events, along with fostering communication and collaborating with partner organizations.' },
-  //   { 
-  //     id: 'head-of-growth2026', 
-  //     title: 'Head of Growth 2026', 
-  //     short: 'Deadline: 2026-05-10', 
-  //     description: 'Organizing workshops, seminars, talks and community events by UU AI Society. In this role, you shall also manage marketing through social media and other outlets, along with communication with participants and visitors.' },
-  // ];
+  const { data: roles } = useCollectionData(subscribeToPositions, []);
+
 
   type FormState = {
     name: string;

--- a/components/pages/BoardApplicationPage.tsx
+++ b/components/pages/BoardApplicationPage.tsx
@@ -10,44 +10,56 @@ import { subscribeToPositions } from "@/lib/firestore/board-positions";
 
 const COVER_LETTER_MAX_CHARS = 3500;
 
+type FormState = {
+  name: string;
+  email: string;
+  phone: string;
+  cvFile: File | null;
+  coverOption: 'text' | 'file';
+  coverText: string;
+  coverFile: File | null;
+  agree: boolean;
+  errors: Record<string,string>;
+  isSubmitting: boolean;
+  submitted: boolean;
+};
+
+const emptyForm = (overrides?: Partial<FormState>): FormState => ({
+  name: '',
+  email: '',
+  phone: '',
+  cvFile: null,
+  coverOption: 'text',
+  coverText: '',
+  coverFile: null,
+  agree: false,
+  errors: {},
+  isSubmitting: false,
+  submitted: false,
+  ...overrides,
+});
+
 export default function BoardApplicationPage() {
   const { data: roles } = useCollectionData(subscribeToPositions, []);
-
-
-  type FormState = {
-    name: string;
-    email: string;
-    phone: string;
-    cvFile: File | null;
-    coverOption: 'text' | 'file';
-    coverText: string;
-    coverFile: File | null;
-    agree: boolean;
-    errors: Record<string,string>;
-    isSubmitting: boolean;
-    submitted: boolean;
-  };
-
-  const emptyForm = (overrides?: Partial<FormState>): FormState => ({
-    name: '',
-    email: '',
-    phone: '',
-    cvFile: null,
-    coverOption: 'text',
-    coverText: '',
-    coverFile: null,
-    agree: false,
-    errors: {},
-    isSubmitting: false,
-    submitted: false,
-    ...overrides,
-  });
 
   const [forms, setForms] = useState<Record<string,FormState>>(() => {
     const map: Record<string,FormState> = {};
     roles.forEach(r => { map[r.id] = emptyForm(); });
     return map;
   });
+
+  // Roles arrive via a client subscription, so seed a form for each role once
+  // they load (and for any role added later) instead of only at first render.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setForms((prev) => {
+      const missing = roles.filter((r) => !prev[r.id]);
+      if (missing.length === 0) return prev;
+      const next: Record<string, FormState> = { ...prev };
+      missing.forEach((r) => { next[r.id] = emptyForm(); });
+      return next;
+    });
+  }, [roles]);
 
   const [openRole, setOpenRole] = useState<string | null>(null);
 
@@ -79,7 +91,7 @@ export default function BoardApplicationPage() {
  
 
   const validateFor = (roleId: string) => {
-    const f = forms[roleId];
+    const f = forms[roleId] ?? emptyForm();
     const e: Record<string,string> = {};
     if (!f.name.trim()) e.name = 'Name is required';
     if (!f.email.trim() || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(f.email)) e.email = 'Valid email required';

--- a/components/pages/TeamApplicationPage.tsx
+++ b/components/pages/TeamApplicationPage.tsx
@@ -20,12 +20,13 @@ import HeroSplash from "@/components/HeroSplash";
 import { LinkedInUrlInput, LINKEDIN_PREFIX } from "@/components/ui/LinkedInUrlInput";
 import TagComponent from "@/components/ui/Tag";
 import PDFDropzone from "@/components/ui/PDFDropzone";
-import { useApp } from "@/contexts/AppContext";
 import { useNotify } from "@/components/ui/Notifications";
 import { auth, refreshSessionCookie } from "@/lib/firebase-client";
 import { loginUrl } from "@/lib/login-redirect";
 import { getUserProfile, type UserProfile } from "@/lib/firestore/users";
 import { subscribeToCampaignQuestions } from "@/lib/firestore/campaignQuestions";
+import { subscribeOpenCampaigns } from "@/lib/firestore/applicationCampaigns";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
 import { getTeamApplicationByUid } from "@/lib/firestore/teamApplications";
 import { MAX_ROLE_RANKING } from "@/lib/constants";
 import { ApplicationCampaign, CampaignQuestion, CampaignRole } from "@/types";
@@ -143,14 +144,14 @@ const CollapsibleDescription: React.FC<{ text: string; className?: string }> = (
 };
 
 export default function TeamApplicationPage() {
-  const { state } = useApp();
   const { notify } = useNotify();
   const router = useRouter();
   const pathname = usePathname();
   const wizardRef = useRef<HTMLDivElement>(null);
 
-  // Find the first open campaign
-  const campaign: ApplicationCampaign | null = state.campaigns.find((c) => c.status === "open") || null;
+  // Find the first open campaign (public view — open campaigns only)
+  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeOpenCampaigns, []);
+  const campaign: ApplicationCampaign | null = campaigns.find((c) => c.status === "open") || null;
 
   // Which standard fields this campaign actually wants shown/required
   const enabledFields = campaign?.enabledStandardFields?.length
@@ -211,20 +212,14 @@ export default function TeamApplicationPage() {
       setHasApplied(false);
       return;
     }
-    // First check from reactive state if available (fast path, admin only)
-    if (state.teamApplications.some(
-      (a) => a.uid === uid && a.campaignId === campaign.id
-    )) {
-      setHasApplied(true);
-      return;
-    }
+    // Check via the server-side-safe query (rules allow self-read)
     const t = setTimeout(() => {
       getTeamApplicationByUid(uid, campaign.id)
         .then((app) => setHasApplied(!!app))
         .catch(() => setHasApplied(false));
     }, 600);
     return () => clearTimeout(t);
-  }, [campaign?.id, authLoading, state.teamApplications, submitted, submitting]);
+  }, [campaign?.id, authLoading, submitted, submitting]);
 
   // Subscribe to custom questions for the active campaign
   useEffect(() => {
@@ -439,7 +434,7 @@ export default function TeamApplicationPage() {
   };
 
   // No open campaigns (loaded, but none are currently open)
-  if (state.campaignsLoaded && !campaign) {
+  if (campaignsLoaded && !campaign) {
     return (
       <div className="min-h-screen bg-background pt-24 pb-12 transition-colors duration-300 flex items-center">
         <div className="max-w-md mx-auto px-4 text-center">

--- a/components/pages/admin/AdminDashboard.tsx
+++ b/components/pages/admin/AdminDashboard.tsx
@@ -197,6 +197,7 @@ const AdminDashboard: React.FC = () => {
                           <button
                             key={child.key}
                             onClick={() => { setSub(key, child.key); changeTab(key); }}
+                            aria-current={subActive ? "page" : undefined}
                             className={`flex items-center w-full px-3 py-2 rounded-md text-sm transition-colors duration-200 cursor-pointer ${
                               subActive
                                 ? 'bg-primary/10 text-primary font-medium'
@@ -262,7 +263,7 @@ const AdminDashboard: React.FC = () => {
                   )}
                   {activeTab === 'members' && (
                     <TabErrorBoundary name="Members">
-                      <MembersTab onChanged={() => { /* could trigger toast */ }} />
+                      <MembersTab />
                     </TabErrorBoundary>
                   )}
                   {activeTab === 'ai-settings' && (

--- a/components/pages/admin/AdminDashboard.tsx
+++ b/components/pages/admin/AdminDashboard.tsx
@@ -1,14 +1,17 @@
 'use client'
 
-
 import React, { useEffect, useRef, useState } from 'react';
 import {
   Calendar,
   Users,
   FileText,
+  HelpCircle,
   TrendingUp,
+  UserRound,
   BriefcaseBusiness,
   Bot,
+  Inbox,
+  ChevronRight,
 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/Card';
 import EventsTab from '@/components/pages/admin/tabs/EventsTab';
@@ -18,51 +21,87 @@ import FAQTab from '@/components/pages/admin/tabs/FAQTab';
 import BoardTab from '@/components/pages/admin/tabs/BoardTab'
 import ApplicationsTab from '@/components/pages/admin/tabs/ApplicationsTab';
 import AnalyticsTab from '@/components/pages/admin/tabs/AnalyticsTab';
-import FAQModal from '@/components/pages/admin/modals/FAQModal';
-import BlogModal from '@/components/pages/admin/modals/BlogModal';
-import GenerateBlogModal from '@/components/pages/admin/modals/GenerateBlogModal';
-import BoardPositionModal, { type BPositionFormState } from './modals/BoardPositionModal';
-import CampaignBuilderModal from '@/components/pages/admin/modals/CampaignBuilderModal';
-import { useApp } from '@/contexts/AppContext';
-import { updatePageMeta } from '@/utils/seo';
-import { addUsedNewsUrls, removeUsedNewsUrls } from '@/lib/firestore/blog-seen';
-import { BlogPost, Event, TeamMember, FAQ, BoardPosition, ApplicationCampaign } from '@/types';
 import MembersTab from '@/components/pages/admin/tabs/membersTab';
 import JobsTab from '@/components/pages/admin/tabs/JobsTab';
 import AISettingsTab from '@/components/pages/admin/tabs/AISettingsTab';
 import BlogAISettingsTab from '@/components/pages/admin/tabs/BlogAISettingsTab';
-import { listUsers } from '@/lib/firestore/users';
-import { auth } from '@/lib/firebase-client';
+import { useApp } from '@/contexts/AppContext';
+import { updatePageMeta } from '@/utils/seo';
 import { TabErrorBoundary } from '@/components/ui/TabErrorBoundary';
+import AdminStatusStrip from '@/components/pages/admin/AdminStatusStrip';
+import { useAdminOverview, type AdminTabKey } from '@/components/pages/admin/useAdminOverview';
+import { ANALYTICS_SUBTABS, type AnalyticsTabKey } from '@/components/pages/admin/tabs/analytics/useAnalyticsData';
 
 const ADMIN_TABS = ['events', 'team', 'blog', 'faq', 'analytics', 'members', 'jobs', 'ai-settings', 'applications', 'board-applications'] as const;
-type AdminTab = typeof ADMIN_TABS[number];
+
+type NavChild = { key: string; label: string };
+type NavItem = {
+  key: AdminTabKey;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children?: NavChild[];
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { key: 'events', label: 'Events', icon: Calendar },
+  { key: 'team', label: 'Team', icon: Users },
+  {
+    key: 'blog', label: 'Blog', icon: FileText, children: [
+      { key: 'posts', label: 'Posts' },
+      { key: 'ai-settings', label: 'AI News Desk' },
+    ],
+  },
+  { key: 'faq', label: 'FAQ', icon: HelpCircle },
+  { key: 'analytics', label: 'Analytics', icon: TrendingUp, children: ANALYTICS_SUBTABS },
+  { key: 'members', label: 'Members', icon: UserRound },
+  { key: 'jobs', label: 'Jobs', icon: BriefcaseBusiness },
+  { key: 'ai-settings', label: 'AI Settings', icon: Bot },
+  { key: 'applications', label: 'Applications', icon: Inbox },
+];
 
 const AdminDashboard: React.FC = () => {
-  const { state, dispatch } = useApp();
-  const [nrUsers, setNrUsers] = useState<number>(0);
-  //const { user, logout } = useAdmin();
+  const { state } = useApp();
   const tabValues = ADMIN_TABS;
-  type Tab = AdminTab;
+  type Tab = AdminTabKey;
   // Restore the tab from the URL (?tab=...) or last-saved preference. Runs in
   // an effect so the initial render matches the server (avoids hydration
   // mismatch on /admin deep links) before syncing to the stored/URL tab.
   const [activeTab, setActiveTab] = useState<Tab>('events');
+  const [blogSubtab, setBlogSubtab] = useState<'posts' | 'ai-settings'>('posts');
+  const [analyticsSubtab, setAnalyticsSubtab] = useState<AnalyticsTabKey>('overview');
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   useEffect(() => {
-    const fromUrl = new URL(window.location.href).searchParams.get('tab');
+    const params = new URL(window.location.href).searchParams;
+    const fromUrl = params.get('tab');
     if (tabValues.includes(fromUrl as Tab)) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setActiveTab(fromUrl as Tab);
+      const sub = params.get('sub');
+      if (fromUrl === 'blog' && (sub === 'posts' || sub === 'ai-settings')) {
+         
+        setBlogSubtab(sub);
+      }
+      if (fromUrl === 'analytics' && ANALYTICS_SUBTABS.some((s) => s.key === sub)) {
+         
+        setAnalyticsSubtab(sub as AnalyticsTabKey);
+      }
       return;
     }
     const saved = localStorage.getItem('adminDashboardTab');
     if (tabValues.includes(saved as Tab)) {
+       
       setActiveTab(saved as Tab);
     }
+    try {
+      const savedExpanded = localStorage.getItem('adminDashboardExpanded');
+      if (savedExpanded) {
+         
+        setExpandedGroups(JSON.parse(savedExpanded));
+      }
+    } catch { /* ignore */ }
   }, [tabValues]);
   // The URL is owned by the restore effect until the user clicks a tab (avoids clobbering ?tab= before restore lands).
   const tabClicked = useRef(false);
-  const [blogSubtab, setBlogSubtab] = useState<'posts' | 'ai-settings'>('posts');
   // Slide direction for the tab-content transition: content enters from the
   // side the clicked tab is on relative to the currently active tab.
   const [slideFrom, setSlideFrom] = useState<'right' | 'left'>('right');
@@ -72,509 +111,174 @@ const AdminDashboard: React.FC = () => {
     setSlideFrom(nextIdx >= curIdx ? 'right' : 'left');
     tabClicked.current = true;
     setActiveTab(next);
+    if (NAV_ITEMS.some((i) => i.key === next && i.children)) {
+      setExpandedGroups((prev) => ({ ...prev, [next]: true }));
+    }
   };
-  const placeholderImage = '/images/logo-highdef.png';
-
-  // Modal states
-  const [showBlogModal, setShowBlogModal] = useState(false);
-  const [showGenerateBlogModal, setShowGenerateBlogModal] = useState(false);
-  const [showFaqModal, setShowFaqModal] = useState(false);
-  const [showBoardPositionModal, setShowBoardPositionModal] = useState(false);
-  const [editingItem, setEditingItem] = useState<Event | TeamMember | BlogPost | null>(null);
-  const [editingFaq, setEditingFaq] = useState<FAQ | null>(null);
-  const [editingBoardPosition, setEditingBoardPosition] = useState<BoardPosition | null>(null);
-  const [showCampaignModal, setShowCampaignModal] = useState(false);
-  const [editingCampaign, setEditingCampaign] = useState<ApplicationCampaign | null>(null);
-  const [blogForm, setBlogForm] = useState({
-    title: '',
-    excerpt: '',
-    content: '',
-    author: '',
-    image: '',
-    tags: [] as string[],
-    published: false
-  });
-
-
-  const [faqForm, setFaqForm] = useState<Pick<FAQ, 'question' | 'answer' | 'category' | 'order' | 'published'>>({
-    question: '',
-    answer: '',
-    category: 'General',
-    order: state.faqs.length + 1,
-    published: true,
-  });
-
-  const [boardPositionForm, setBoardPositionForm] = useState<BPositionFormState>({
-    title: '',
-    short: '',
-    description: ''
-  });
+  const setSub = (tab: Tab, sub: string) => {
+    if (tab === 'blog') setBlogSubtab(sub as 'posts' | 'ai-settings');
+    else if (tab === 'analytics') setAnalyticsSubtab(sub as AnalyticsTabKey);
+  };
+  const toggleGroup = (key: AdminTabKey) => {
+    setExpandedGroups((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+  const { items, loaded } = useAdminOverview();
 
   useEffect(() => {
     updatePageMeta('Admin Dashboard', 'Manage UU AI Society content and events');
-    (async () => {
-      setNrUsers((await listUsers()).length);
-    })();
   }, []);
 
   useEffect(() => {
     localStorage.setItem('adminDashboardTab', activeTab);
+    localStorage.setItem('adminDashboardExpanded', JSON.stringify(expandedGroups));
     if (!tabClicked.current) return;
     const url = new URL(window.location.href);
-    const current = url.searchParams.get('tab');
-    if (current !== activeTab) {
+    if (url.searchParams.get('tab') !== activeTab) {
       url.searchParams.set('tab', activeTab);
-      window.history.replaceState(null, '', url.toString());
     }
-  }, [activeTab]);
+    const sub = activeTab === 'blog' ? blogSubtab : activeTab === 'analytics' ? analyticsSubtab : null;
+    if (sub) url.searchParams.set('sub', sub);
+    else url.searchParams.delete('sub');
+    window.history.replaceState(null, '', url.toString());
+  }, [activeTab, blogSubtab, analyticsSubtab, expandedGroups]);
 
-  const stats = [
-    {
-      title: 'Total Events',
-      value: state.events.length,
-      icon: Calendar,
-      color: 'bg-blue-500'
-    },
-    {
-      title: 'Team Members',
-      value: state.teamMembers.length,
-      icon: Users,
-      color: 'bg-green-500'
-    },
-    {
-      title: 'Blog Posts',
-      value: state.blogPosts.length,
-      icon: FileText,
-      color: 'bg-purple-500'
-    },
-    {
-      title: 'Users registered',
-      value: nrUsers || 'N/A',
-      icon: TrendingUp,
-      color: 'bg-red-500'
-    },
-    {
-      title: 'Job Postings',
-      value: state.jobs.length,
-      icon: BriefcaseBusiness,
-      color: 'bg-yellow-500'
-    }
-  ];
-
-  const resetForms = () => {
-    setBlogForm({
-      title: '',
-      excerpt: '',
-      content: '',
-      author: '',
-      image: '',
-      tags: [],
-      published: false
-    });
-    setBoardPositionForm({
-      title: '',
-      short: '',
-      description: ''
-    });
-    setEditingItem(null);
-  };
-
-
-  const reviewerName = () => auth.currentUser?.displayName || auth.currentUser?.email || '';
-
-  // Seen-URL lifecycle: cited sources become "covered" at publish and are released on unpublish/delete.
-  const syncSeenUrlsForPost = (post: BlogPost) => {
-    const urls = (post.sources ?? []).map((s) => s.url).filter(Boolean);
-    if (urls.length === 0) return;
-    if (post.published) {
-      addUsedNewsUrls(urls).catch((e) => console.warn('Failed to mark post sources as used:', e));
-    } else {
-      removeUsedNewsUrls(urls).catch((e) => console.warn('Failed to release post sources:', e));
-    }
-  };
-
-  const handleAddBlogPost = () => {
-    const newPost = {
-      ...blogForm,
-      image: blogForm.image || placeholderImage,
-      date: new Date().toISOString().split('T')[0]
-    } as BlogPost;
-    if (newPost.published && newPost.authorType === 'ai' && !newPost.reviewedBy) {
-      newPost.reviewedBy = reviewerName();
-    }
-    dispatch({ firestoreAction: 'ADD_BLOG_POST', payload: newPost });
-    syncSeenUrlsForPost(newPost);
-    setShowBlogModal(false);
-    resetForms();
-  };
-
-  const handleAddFaq = () => {
-    const payload = { ...faqForm };
-    dispatch({ firestoreAction: 'ADD_FAQS', payload });
-    setShowFaqModal(false);
-    setFaqForm({ question: '', answer: '', category: 'General', order: state.faqs.length + 1, published: true });
-  };
-
-  const handleUpdateFaq = () => {
-    if (!editingFaq) return;
-    dispatch({ firestoreAction: 'UPDATE_FAQS', payload: { ...editingFaq, ...faqForm } as FAQ });
-    setShowFaqModal(false);
-    setEditingFaq(null);
-  };
-
-  const handleDeleteFaq = (id: string) => {
-    if (window.confirm('Delete this FAQ?')) {
-      dispatch({ firestoreAction: 'DELETE_FAQS', payload: id });
-    }
-  };
-
-  const handleAddBoardPosition = () => {
-    dispatch({ firestoreAction: 'ADD_BOARDPOS', payload: { ...boardPositionForm } });
-    setShowBoardPositionModal(false);
-    setBoardPositionForm({ title: '', short: '', description: '' });
-  };
-
-  const handleUpdateBoardPosition = () => {
-    if (!editingBoardPosition) return;
-    dispatch({
-      firestoreAction: 'UPDATE_BOARDPOS',
-      payload: { id: editingBoardPosition.id, ...boardPositionForm } as BoardPosition,
-    });
-    setShowBoardPositionModal(false);
-    setEditingBoardPosition(null);
-  };
-
-  const handleDeleteBoardPosition = (id: string) => {
-    if (window.confirm('Delete this Board Position?')) {
-      dispatch({ firestoreAction: 'DELETE_BOARDPOS', payload: id });
-    }
-  };
-
-  const handleDeleteBoardApplication = (id: string) => {
-    if (window.confirm('Delete this application record?')) {
-      dispatch({ firestoreAction: 'DELETE_BOARD_APPLICATION', payload: id });
-    }
-  };
-
-  const handleMoveBoardPosition = (positionId: string, direction: 'up' | 'down') => {
-    dispatch({ firestoreAction: 'MOVE_BOARDPOS', payload: { positionId, direction } });
-  };
-
-  const handleSaveCampaign = async (data: { id?: string; title: string; subtitle: string; description: string; deadline: string; status: 'open' | 'closed' | 'draft'; teams: string[]; roles: ApplicationCampaign['roles']; teamInfo?: Record<string, { name?: string; description?: string }>; enabledStandardFields: string[] }): Promise<string | undefined> => {
-    if (data.id) {
-      // Update existing
-      dispatch({ firestoreAction: 'UPDATE_CAMPAIGN', payload: { id: data.id, title: data.title, subtitle: data.subtitle, description: data.description, deadline: data.deadline, status: data.status, teams: data.teams, roles: data.roles, teamInfo: data.teamInfo, enabledStandardFields: data.enabledStandardFields } as ApplicationCampaign });
-      return data.id;
-    } else {
-      // Add new — dispatch returns the doc id
-      const id = await dispatch({ firestoreAction: 'ADD_CAMPAIGN', payload: { title: data.title, subtitle: data.subtitle, description: data.description, deadline: data.deadline, status: data.status, teams: data.teams, roles: data.roles, teamInfo: data.teamInfo, enabledStandardFields: data.enabledStandardFields } });
-      return typeof id === 'string' ? id : undefined;
-    }
-  };
-
-  const handleDeleteCampaign = (id: string) => {
-    if (window.confirm('Delete this campaign and all its custom questions? Submissions will remain in Firestore.')) {
-      dispatch({ firestoreAction: 'DELETE_CAMPAIGN', payload: id });
-    }
-  };
-
-  const handleDeleteTeamApplication = (id: string, emailNormalized: string, campaignId: string) => {
-    if (window.confirm('Delete this submission?')) {
-      import('@/lib/firestore/teamApplications').then((mod) =>
-        mod.deleteTeamApplicationWithLimits(id, emailNormalized, campaignId)
-      ).catch(console.error);
-    }
-  };
-
-  const handleEditBlogPost = (post: BlogPost) => {
-    setEditingItem(post);
-    setBlogForm({
-      title: post.title,
-      excerpt: post.excerpt,
-      content: post.content,
-      author: post.author,
-      image: post.image,
-      tags: post.tags,
-      published: post.published
-    });
-    setShowBlogModal(true);
-  };
-
-  const handleUpdateBlogPost = () => {
-    if (editingItem) {
-      const updatedPost = { ...editingItem, ...blogForm } as BlogPost;
-      if (updatedPost.published && updatedPost.authorType === 'ai' && !updatedPost.reviewedBy) {
-        updatedPost.reviewedBy = reviewerName();
-      }
-      dispatch({ firestoreAction: 'UPDATE_BLOG_POST', payload: updatedPost });
-      syncSeenUrlsForPost(updatedPost);
-      setShowBlogModal(false);
-      resetForms();
-    }
-  };
-
-
-  const handleDeleteBlogPost = (postId: string) => {
-    if (window.confirm('Are you sure you want to delete this blog post?')) {
-      dispatch({ firestoreAction: 'DELETE_BLOG_POST', payload: postId });
-    }
-  };
-
-  const toggleBlogPostVisibility = (post: BlogPost) => {
-    const payload: BlogPost = { ...post, published: !post.published };
-    if (payload.published && post.authorType === 'ai' && !post.reviewedBy) {
-      payload.reviewedBy = reviewerName();
-    }
-    dispatch({ firestoreAction: 'UPDATE_BLOG_POST', payload });
-    syncSeenUrlsForPost(payload);
-  };
-
-  const toggleBlogPostFeatured = (post: BlogPost) => {
-    dispatch({ firestoreAction: 'UPDATE_BLOG_POST', payload: { ...post, featured: !post.featured } });
-  };
-
-  const handleDraftCreated = async (draftId: string) => {
-    setShowGenerateBlogModal(false);
-    try {
-      const mod = await import('@/lib/firestore/blog');
-      const post = await mod.getBlogPostById(draftId);
-      if (post) {
-        handleEditBlogPost(post);
-      }
-    } catch (e) {
-      console.error('Failed to load generated draft:', e);
-    }
-  };
+  const isSubActive = (parent: NavItem, childKey: string) =>
+    activeTab === parent.key &&
+    (parent.key === 'blog' ? blogSubtab === childKey : analyticsSubtab === childKey);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-4 pt-20 md:py-8 md:pt-24">
-      <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-background transition-colors pb-24">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
-        <div className="mb-4 md:mb-8 flex justify-between items-start gap-4">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">Admin Dashboard</h1>
-            <p className="text-gray-600 dark:text-gray-300">Manage your UU AI Society content and events</p>
-          </div>
+        <div className="mb-6">
+          <h1 className="text-2xl md:text-3xl font-semibold tracking-[-0.032em] text-foreground">Admin Dashboard</h1>
+          <p className="text-muted-foreground text-sm mt-1">Manage your UU AI Society content and events</p>
         </div>
 
-        {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3 md:gap-6 mb-4 md:mb-8 items-center">
-          {stats.map((stat, index) => (
-            <Card key={index} className="h-full">
-              <CardContent className="pl-6 pr-6 pt-6 h-full">
-                <div className="flex items-center h-full">
-                  <div className={`p-3 rounded-lg ${stat.color} text-white mr-4`}>
-                    <stat.icon className="h-6 w-6" />
+        {/* What needs attention */}
+        <AdminStatusStrip items={items} loaded={loaded} onNavigate={changeTab} />
+
+        {/* Sidebar + content */}
+        <div className="mt-8 lg:grid lg:grid-cols-[13rem_1fr] lg:gap-8 lg:items-start">
+          <nav aria-label="Admin sections" className="flex lg:flex-col gap-1 overflow-x-auto pb-2 mb-6 lg:mb-0 lg:pb-0 lg:sticky lg:top-20 [mask-image:linear-gradient(to_right,black_88%,transparent)] lg:[mask-image:none]">
+            {NAV_ITEMS.map((item) => {
+              const { key, label, icon: Icon, children } = item;
+              const isOpen = expandedGroups[key] !== false && (activeTab === key || expandedGroups[key] === true);
+              const isActive = activeTab === key;
+              return (
+                <div key={key} className="shrink-0">
+                  <div className={`flex items-center rounded-md transition-colors duration-200 ${isActive ? 'bg-primary/10' : 'hover:bg-foreground/[0.04]'}`}>
+                    <button
+                      onClick={() => changeTab(key)}
+                      className={`flex items-center gap-2.5 flex-1 px-3 py-3 rounded-md text-sm transition-colors duration-200 cursor-pointer ${
+                        isActive ? 'text-primary font-medium' : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      <Icon className="h-4 w-4 shrink-0" aria-hidden />
+                      {label}
+                    </button>
+                    {children && (
+                      <button
+                        type="button"
+                        onClick={() => toggleGroup(key)}
+                        aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${label}`}
+                        aria-expanded={isOpen}
+                        className="p-2 mr-1 rounded-md text-muted-foreground hover:text-foreground cursor-pointer"
+                      >
+                        <ChevronRight className={`h-4 w-4 transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`} />
+                      </button>
+                    )}
                   </div>
-                  <div>
-                    <p className="text-2xl font-bold text-gray-900 dark:text-white">{stat.value}</p>
-                    <p className="text-gray-600 dark:text-gray-300 text-sm">{stat.title}</p>
-                  </div>
+                  {children && isOpen && (
+                    <div className="ml-4 lg:ml-3 border-l border-border pl-2 lg:pl-3 space-y-0.5 my-1">
+                      {children.map((child) => {
+                        const subActive = isSubActive(item, child.key);
+                        return (
+                          <button
+                            key={child.key}
+                            onClick={() => { setSub(key, child.key); changeTab(key); }}
+                            className={`flex items-center w-full px-3 py-2 rounded-md text-sm transition-colors duration-200 cursor-pointer ${
+                              subActive
+                                ? 'bg-primary/10 text-primary font-medium'
+                                : 'text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04]'
+                            }`}
+                          >
+                            {child.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </nav>
+
+          <div className="min-w-0">
+            <Card variant="elevated" className="p-4 md:p-6">
+              <CardContent className="p-0">
+                <div
+                  key={`${activeTab}-${activeTab === 'blog' ? blogSubtab : activeTab === 'analytics' ? analyticsSubtab : ''}`}
+                  className={`animate-in fade-in duration-300 ease-out ${slideFrom === 'right' ? 'slide-in-from-right-4' : 'slide-in-from-left-4'}`}
+                >
+                  {activeTab === 'events' && (
+                    <TabErrorBoundary name="Events">
+                      <EventsTab events={state.events} />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'jobs' && (
+                    <TabErrorBoundary name="Jobs">
+                      <JobsTab />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'team' && (
+                    <TabErrorBoundary name="Team">
+                      <TeamTab members={state.teamMembers} />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'blog' && (
+                    <TabErrorBoundary name="Blog">
+                      {blogSubtab === 'posts' ? (
+                        <BlogTab />
+                      ) : (
+                        <BlogAISettingsTab />
+                      )}
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'analytics' && (
+                    <TabErrorBoundary name="Analytics">
+                      <AnalyticsTab activeSubtab={analyticsSubtab} onSelectSubtab={(k) => setAnalyticsSubtab(k)} />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'faq' && (
+                    <TabErrorBoundary name="FAQ">
+                      <FAQTab />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'board-applications' && (
+                    <TabErrorBoundary name="Board Applications">
+                      <BoardTab />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'members' && (
+                    <TabErrorBoundary name="Members">
+                      <MembersTab onChanged={() => { /* could trigger toast */ }} />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'ai-settings' && (
+                    <TabErrorBoundary name="AI Settings">
+                      <AISettingsTab />
+                    </TabErrorBoundary>
+                  )}
+                  {activeTab === 'applications' && (
+                    <TabErrorBoundary name="Applications">
+                      <ApplicationsTab />
+                    </TabErrorBoundary>
+                  )}
                 </div>
               </CardContent>
             </Card>
-          ))}
-        </div>
-
-        {/* Navigation Tabs */}
-        <div className="overflow-x-auto mb-4 md:mb-8">
-          <div className="pb-4 border-b border-gray-200 dark:border-gray-700">
-            <nav className="-mb-px flex space-x-8 md:space-x-12">
-              {([
-                { key: 'events', label: 'Events', icon: Calendar },
-                { key: 'team', label: 'Team', icon: Users },
-                { key: 'blog', label: 'Blog', icon: FileText },
-                { key: 'faq', label: 'FAQ', icon: FileText },
-                { key: 'analytics', label: 'Analytics', icon: TrendingUp },
-                { key: 'members', label: 'Members', icon: Users },
-                { key: 'jobs', label: 'Jobs', icon: BriefcaseBusiness },
-                { key: 'ai-settings', label: 'AI Settings', icon: Bot },
-                { key: 'applications', label: 'Applications', icon: Users },
-                // { key: 'board-applications', label: "GA'26 Board Applications", icon: Users},
-              ] as const).map(({ key, label, icon: Icon }) => (
-                <button
-                  key={key}
-                  onClick={() => changeTab(key)}
-                  className={`cursor-pointer flex items-center py-2 px-3 border-b-2 font-medium text-sm transition-all duration-200 ease-in-out ${activeTab === key
-                    ? 'border-primary text-primary'
-                    : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
-                    }`}
-                >
-                  <Icon className="h-4 w-4 mr-2" />
-                  {label}
-                </button>
-              ))}
-            </nav>
           </div>
-        </div>
-
-        {/* Tab Content */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 md:p-6">
-          <div
-            key={activeTab}
-            className={`animate-in fade-in duration-300 ease-out ${slideFrom === 'right' ? 'slide-in-from-right-4' : 'slide-in-from-left-4'}`}
-          >
-          {activeTab === 'events' && (
-            <TabErrorBoundary name="Events">
-              <EventsTab
-                events={state.events}
-                onManageQuestions={() => { }}
-                onViewRegistrations={() => { }}
-              />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'jobs' && (
-            <TabErrorBoundary name="Jobs">
-              <JobsTab />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'team' && (
-            <TabErrorBoundary name="Team">
-              <TeamTab
-                members={state.teamMembers}
-              />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'blog' && (
-            <TabErrorBoundary name="Blog">
-              <div className="flex bg-foreground/[0.05] rounded-md p-1 gap-1 mb-6 w-fit">
-                {([
-                  ['posts', 'Posts'],
-                  ['ai-settings', 'AI News Desk'],
-                ] as const).map(([key, label]) => (
-                  <button
-                    key={key}
-                    type="button"
-                    aria-pressed={blogSubtab === key}
-                    onClick={() => setBlogSubtab(key)}
-                    className={`px-4 py-2 rounded text-sm font-medium transition-colors duration-300 ${
-                      blogSubtab === key
-                        ? 'bg-primary text-primary-foreground'
-                        : 'text-foreground/60 hover:text-foreground'
-                    }`}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-              {blogSubtab === 'posts' ? (
-                <BlogTab
-                  posts={state.blogPosts}
-                  onAddClick={() => setShowBlogModal(true)}
-                  onGenerateClick={() => setShowGenerateBlogModal(true)}
-                  onEdit={(post) => handleEditBlogPost(post)}
-                  onDelete={(id) => handleDeleteBlogPost(id)}
-                  onTogglePublish={(post) => toggleBlogPostVisibility(post)}
-                  onToggleFeatured={toggleBlogPostFeatured}
-                />
-              ) : (
-                <BlogAISettingsTab />
-              )}
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'analytics' && (
-            <TabErrorBoundary name="Analytics">
-              <AnalyticsTab />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'faq' && (
-            <TabErrorBoundary name="FAQ">
-              <FAQTab
-                faqs={state.faqs}
-                onAddClick={() => { setEditingFaq(null); setFaqForm({ question: '', answer: '', category: 'General', order: state.faqs.length + 1, published: true }); setShowFaqModal(true); }}
-                onEdit={(faq) => { setEditingFaq(faq); setFaqForm({ question: faq.question, answer: faq.answer, category: faq.category, order: faq.order, published: faq.published }); setShowFaqModal(true); }}
-                onDelete={(id) => handleDeleteFaq(id)}
-              />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'board-applications' && (
-            <TabErrorBoundary name="Board Applications">
-              <BoardTab
-                applicants={state.applicants} 
-                boardPositions={state.boardPositions}
-                onAddClick={() => { setEditingBoardPosition(null); setBoardPositionForm({ title: '', short: '', description: '' }); setShowBoardPositionModal(true); }}
-                onEdit={(position) => { setEditingBoardPosition(position); setBoardPositionForm({ title: position.title, short: position.short, description: position.description }); setShowBoardPositionModal(true); }}
-                onDeletePosition={handleDeleteBoardPosition}
-                onDeleteApplicant={handleDeleteBoardApplication}
-                onMovePosition={handleMoveBoardPosition}
-              />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'members' && (
-            <TabErrorBoundary name="Members">
-              <MembersTab onChanged={() => { /* could trigger toast */ }} />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'ai-settings' && (
-            <TabErrorBoundary name="AI Settings">
-              <AISettingsTab />
-            </TabErrorBoundary>
-          )}
-          {activeTab === 'applications' && (
-            <TabErrorBoundary name="Applications">
-              <ApplicationsTab
-                campaigns={state.campaigns}
-                applications={state.teamApplications}
-                onAddCampaign={() => { setEditingCampaign(null); setShowCampaignModal(true); }}
-                onEditCampaign={(c) => { setEditingCampaign(c); setShowCampaignModal(true); }}
-                onDeleteCampaign={handleDeleteCampaign}
-                onUpdateCampaignStatus={(id, status) => dispatch({ firestoreAction: 'UPDATE_CAMPAIGN', payload: { id, status } })}
-                onDeleteApplication={handleDeleteTeamApplication}
-              />
-            </TabErrorBoundary>
-          )}
-          </div>
-
-          {/* Blog Modal */}
-          <BlogModal
-            open={showBlogModal}
-            editing={!!editingItem}
-            form={blogForm}
-            setForm={setBlogForm}
-            onClose={() => { setShowBlogModal(false); resetForms(); }}
-            onSubmit={() => {
-              if (editingItem) {
-                handleUpdateBlogPost();
-              } else {
-                handleAddBlogPost();
-              }
-            }}
-          />
-
-          <GenerateBlogModal
-            open={showGenerateBlogModal}
-            onClose={() => setShowGenerateBlogModal(false)}
-            onDraftCreated={handleDraftCreated}
-          />
-
-          <FAQModal
-            open={showFaqModal}
-            onClose={() => { setShowFaqModal(false); setEditingFaq(null); }}
-            form={faqForm}
-            setForm={setFaqForm}
-            editing={!!editingFaq}
-            onAdd={handleAddFaq}
-            onUpdate={handleUpdateFaq}
-          />
-
-          <BoardPositionModal
-            open={showBoardPositionModal}
-            onClose={() => { setShowBoardPositionModal(false); setEditingBoardPosition(null); }}
-            form={boardPositionForm}
-            setForm={setBoardPositionForm}
-            editing={!!editingBoardPosition}
-            onAdd={handleAddBoardPosition}
-            onUpdate={handleUpdateBoardPosition}
-          />
-
-          <CampaignBuilderModal
-            open={showCampaignModal}
-            campaign={editingCampaign}
-            isNew={!editingCampaign}
-            onClose={() => { setShowCampaignModal(false); setEditingCampaign(null); }}
-            onSaveCampaign={handleSaveCampaign}
-          />
-
         </div>
       </div>
     </div>

--- a/components/pages/admin/AdminStatusStrip.tsx
+++ b/components/pages/admin/AdminStatusStrip.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from "react";
+import type { AdminActionItem, AdminTabKey } from "./useAdminOverview";
+
+interface Props {
+  items: AdminActionItem[];
+  loaded: boolean;
+  onNavigate: (tab: AdminTabKey) => void;
+}
+
+/** The admin "what needs attention" strip — actionable signals in mono counts, not marketing metrics; quiet when everything is handled. */
+const AdminStatusStrip: React.FC<Props> = ({ items, loaded, onNavigate }) => {
+  return (
+    <div className="flex flex-wrap items-center gap-x-7 gap-y-3 rounded-xl border border-border bg-card/70 glass-shadow px-5 py-4">
+      {!loaded ? (
+        <p className="mono-label text-muted-foreground/60">Loading…</p>
+      ) : items.length === 0 ? (
+        <p className="mono-label text-muted-foreground">Nothing needs attention.</p>
+      ) : (
+        items.map((item) => (
+          <button
+            key={`${item.tab}-${item.label}`}
+            type="button"
+            onClick={() => onNavigate(item.tab)}
+            className="group flex items-baseline gap-2 text-left cursor-pointer rounded-sm"
+          >
+            <span className="font-mono text-sm font-semibold tabular-nums text-primary">{item.count}</span>
+            <span className="text-sm text-muted-foreground transition-colors duration-200 group-hover:text-foreground">
+              {item.label}
+            </span>
+          </button>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default AdminStatusStrip;

--- a/components/pages/admin/modals/EventModal.tsx
+++ b/components/pages/admin/modals/EventModal.tsx
@@ -201,8 +201,8 @@ const EventModal: React.FC<EventModalProps> = ({ open, editing, form, setForm, o
           )}
         </div>
 
-        <div className="rounded-lg border border-gray-200 dark:border-gray-600 p-4 space-y-3 bg-gray-50/50 dark:bg-gray-900/30">
-          <p className="text-sm font-medium text-gray-900 dark:text-white">External registration</p>
+        <div className="rounded-lg border border-border p-4 space-y-3 bg-foreground/[0.03]">
+          <p className="text-sm font-medium text-foreground">External registration</p>
           <FieldGroup label="Registration link (optional)">
             <InputBase
               id="external-registration-url"
@@ -212,7 +212,7 @@ const EventModal: React.FC<EventModalProps> = ({ open, editing, form, setForm, o
               className={fieldClasses}
               placeholder="https://…"
             />
-            <p className="text-xs text-gray-500 mt-1 dark:text-gray-400">
+            <p className="text-xs text-muted-foreground mt-1">
               If set, the event detail page shows a button that opens this URL in a new tab.
             </p>
           </FieldGroup>
@@ -220,7 +220,7 @@ const EventModal: React.FC<EventModalProps> = ({ open, editing, form, setForm, o
             <input
               id="external-registration-members-only"
               type="checkbox"
-              className="mt-1 rounded border-gray-300 shrink-0"
+              className="mt-1 rounded border-border shrink-0"
               checked={form.externalRegistrationMembersOnly}
               onChange={(e) =>
                 setForm((prev) => ({
@@ -232,11 +232,11 @@ const EventModal: React.FC<EventModalProps> = ({ open, editing, form, setForm, o
             <div>
               <label
                 htmlFor="external-registration-members-only"
-                className="text-sm font-medium text-gray-900 dark:text-white cursor-pointer"
+                className="text-sm font-medium text-foreground cursor-pointer"
               >
                 Require sign-in to view the link
               </label>
-              <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+              <p className="text-xs text-muted-foreground mt-0.5">
                 When checked, visitors who are not logged in see a disabled control and must sign in before they can open the external registration page.
               </p>
             </div>

--- a/components/pages/admin/modals/EventQuestionsModal.tsx
+++ b/components/pages/admin/modals/EventQuestionsModal.tsx
@@ -103,12 +103,12 @@ const EventQuestionsModal: React.FC<EventQuestionsModalProps> = ({ open, eventTi
     >
       <div className="space-y-3 mb-6">
         {sortedQuestions.map((q) => (
-          <div key={q.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 flex items-start justify-between">
+          <div key={q.id} className="border border-border rounded p-3 flex items-start justify-between">
             <div>
               <div className="font-medium">{q.question}{q.id?.startsWith('default:') ? ' (default)' : ''}</div>
-              <div className="text-xs text-gray-500 dark:text-gray-400">{q.type} • Order {q.order} • {q.required ? 'Required' : 'Optional'}</div>
+              <div className="text-xs text-muted-foreground">{q.type} • Order {q.order} • {q.required ? 'Required' : 'Optional'}</div>
               {q.options && q.options.length > 0 && (
-                <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">Options: {q.options.join(', ')}</div>
+                <div className="text-xs text-muted-foreground mt-1">Options: {q.options.join(', ')}</div>
               )}
             </div>
             <div className="flex gap-2">
@@ -122,11 +122,11 @@ const EventQuestionsModal: React.FC<EventQuestionsModalProps> = ({ open, eventTi
           </div>
         ))}
         {sortedQuestions.length === 0 && (
-          <div className="text-sm text-gray-500 dark:text-gray-400">No questions yet.</div>
+          <div className="text-sm text-muted-foreground">No questions yet.</div>
         )}
       </div>
 
-      <form onSubmit={submit} className="space-y-4 border-t border-gray-200 dark:border-gray-700 pt-4" data-event-id={eventId}>
+      <form onSubmit={submit} className="space-y-4 border-t border-border pt-4" data-event-id={eventId}>
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold">{mode === 'edit' ? 'Edit Question' : 'Add New Question'}</h3>
           {mode === 'add' && (

--- a/components/pages/admin/modals/EventRegistrationsModal.tsx
+++ b/components/pages/admin/modals/EventRegistrationsModal.tsx
@@ -216,16 +216,16 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
       size="xl"
       className="p-0"
       header={
-        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between p-4 border-b border-border">
           <div className="flex items-center gap-2">
-            <Users className="h-5 w-5 text-gray-700 dark:text-gray-300" aria-hidden />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Registrations — {eventTitle}</h2>
+            <Users className="h-5 w-5 text-foreground/80" aria-hidden />
+            <h2 className="text-lg font-semibold text-foreground">Registrations — {eventTitle}</h2>
           </div>
           <button
             type="button"
             onClick={onClose}
             aria-label="Close dialog"
-            className="size-9 grid place-items-center rounded-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-700/60 transition-colors cursor-pointer"
+            className="size-9 grid place-items-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-foreground/[0.05] transition-colors cursor-pointer"
           >
             <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
               <path d="M18 6 6 18" /><path d="m6 6 12 12" />
@@ -236,13 +236,13 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
     >
       <div className="p-4">
           {registrations.length === 0 ? (
-            <p className="text-sm text-gray-600 dark:text-gray-300">No registrations yet.</p>
+            <p className="text-sm text-foreground/80">No registrations yet.</p>
           ) : (
             <>
               {/* Top controls: count + bulk actions */}
               <div className="flex items-center justify-between mb-2 gap-2 flex-wrap">
-                <div className="text-sm text-gray-700 dark:text-gray-300">Total registrations: <span className="font-medium text-gray-900 dark:text-white">{registrations.length}</span></div>
-                <div className="text-xs text-gray-700 dark:text-gray-300 flex flex-col sm:flex-row sm:items-center gap-1">
+                <div className="text-sm text-foreground/80">Total registrations: <span className="font-medium text-foreground">{registrations.length}</span></div>
+                <div className="text-xs text-foreground/80 flex flex-col sm:flex-row sm:items-center gap-1">
                   <span>Present: <span className="font-semibold">{attendedCount || 0}</span></span>
                   <span className="sm:ml-3">Attendance: <span className="font-semibold">{attendancePct}%</span></span>
                 </div>
@@ -259,7 +259,7 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
                     return (
                   <Button
                     size="sm"
-                    className="bg-blue-600 text-white"
+                    className="bg-primary text-primary-foreground"
                     disabled={true} //bulkInviting || registrations.every(r => !(selected[r.id] && (r.status === 'registered' || r.status === 'waitlist')))}
                     onClick={async () => {
                       setBulkInviting(true);
@@ -368,7 +368,7 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
 
                       return (
                         <React.Fragment key={r.id}>
-                          <TableRow className={`border-t border-gray-200 dark:border-gray-700 hover:bg-gray-200/40 dark:hover:bg-gray-900/20
+                          <TableRow className={`border-t border-border hover:bg-foreground/[0.04]
                             ${isPresent ? 'bg-green-200/80 dark:bg-green-900/20 hover:bg-green-200/90 dark:hover:bg-green-900/40' : ''}`}>
                             <TableCell className="py-2 pr-2">
                               <input
@@ -420,16 +420,16 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
                             </TableCell>
                           </TableRow>
                           {expanded[r.id] && (
-                            <TableRow className="bg-gray-50/60 dark:bg-gray-900/50">
+                            <TableRow className="bg-foreground/[0.03]">
                               <TableCell colSpan={6} className="p-3">
                                 {(() => {
                                   const profile = r.userId ? userProfiles[r.userId] : undefined;
                                   if (profile?.program || profile?.expectedGraduationYear) {
                                     return (
-                                      <div className="mb-3 pb-3 border-b border-gray-200 dark:border-gray-700 text-sm text-gray-700 dark:text-gray-300">
-                                        <span className="font-medium">Program:</span> {profile.program || <span className="text-gray-400 italic">Not provided</span>}
+                                      <div className="mb-3 pb-3 border-b border-border text-sm text-foreground/80">
+                                        <span className="font-medium">Program:</span> {profile.program || <span className="text-muted-foreground italic">Not provided</span>}
                                         <span className="mx-2">|</span>
-                                        <span className="font-medium">Graduation Year:</span> {profile.expectedGraduationYear || <span className="text-gray-400 italic">Not provided</span>}
+                                        <span className="font-medium">Graduation Year:</span> {profile.expectedGraduationYear || <span className="text-muted-foreground italic">Not provided</span>}
                                       </div>
                                     );
                                   }
@@ -446,8 +446,8 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
                                     <TableBody>
                                       {questions.map((q) => (
                                         <TableRow key={q.id}>
-                                          <TableCell className="align-top text-gray-600 dark:text-gray-300">{q.question}</TableCell>
-                                          <TableCell className="align-top text-gray-900 dark:text-white whitespace-pre-wrap wrap-break-word">
+                                          <TableCell className="align-top text-foreground/80">{q.question}</TableCell>
+                                          <TableCell className="align-top text-foreground whitespace-pre-wrap wrap-break-word">
                                             {getAnswer(q) || '—'}
                                           </TableCell>
                                         </TableRow>
@@ -465,8 +465,8 @@ const EventRegistrationsModal: React.FC<EventRegistrationsModalProps> = ({ open,
                                     <TableBody>
                                       {Object.entries(r.registrationData || {}).map(([k, v]) => (
                                         <TableRow key={k}>
-                                          <TableCell className="align-top text-gray-600 dark:text-gray-300">{k}</TableCell>
-                                          <TableCell className="align-top text-gray-900 dark:text-white whitespace-pre-wrap wrap-break-word">
+                                          <TableCell className="align-top text-foreground/80">{k}</TableCell>
+                                          <TableCell className="align-top text-foreground whitespace-pre-wrap wrap-break-word">
                                             {Array.isArray(v) ? v.join(', ') : typeof v === 'boolean' ? (v ? 'Yes' : 'No') : String(v ?? '')}
                                           </TableCell>
                                         </TableRow>

--- a/components/pages/admin/modals/JobModal.tsx
+++ b/components/pages/admin/modals/JobModal.tsx
@@ -80,7 +80,7 @@ const JobModal: React.FC<JobModalProps> = ({ open, editing, form, setForm, onClo
 
         <div className="flex items-center gap-2">
           <input id="job-published" type="checkbox" checked={!!form.published} onChange={(e) => setForm(prev => ({ ...prev, published: e.target.checked }))} />
-          <label htmlFor="job-published" className="text-gray-700 dark:text-white">Published</label>
+          <label htmlFor="job-published" className="text-foreground/80">Published</label>
         </div>
 
         <div className="flex justify-end space-x-3 pt-4">

--- a/components/pages/admin/modals/TeamModal.tsx
+++ b/components/pages/admin/modals/TeamModal.tsx
@@ -118,9 +118,9 @@ const TeamModal: React.FC<TeamModalProps> = ({ open, editing, form, setForm, onC
             <InputBase type="text" value={form.position} onChange={(e) => setForm(prev => ({ ...prev, position: e.target.value }))} required />
           </FieldGroup>
           <FieldGroup label="Teams">
-            <div className="grid grid-cols-2 gap-1.5 p-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-700">
+            <div className="grid grid-cols-2 gap-1.5 p-2 border border-border rounded-md bg-card">
               {TEAM_CATEGORIES.map(cat => (
-                <label key={cat} className="flex items-center gap-2 text-sm text-gray-900 dark:text-white cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-600 rounded px-1 py-0.5">
+                <label key={cat} className="flex items-center gap-2 text-sm text-foreground cursor-pointer hover:bg-foreground/[0.05] rounded px-1 py-0.5">
                   <input
                     type="checkbox"
                     checked={form.teams.includes(cat)}
@@ -142,7 +142,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ open, editing, form, setForm, onC
             onChange={(e) => setForm(prev => ({ ...prev, badge: e.target.value }))}
             placeholder="e.g. Head of, Lead, Chairman"
           />
-          <p className="text-xs text-gray-500 mt-1">Shown as a small colored chip on the public card</p>
+          <p className="text-xs text-muted-foreground mt-1">Shown as a small colored chip on the public card</p>
         </FieldGroup>
 
         <FieldGroup label="Bio (optional)">
@@ -158,7 +158,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ open, editing, form, setForm, onC
             uploading={uploading}
             deleting={deleting}
           />
-          <p className="text-xs text-gray-500">Optional; a placeholder will be used if empty</p>
+          <p className="text-xs text-muted-foreground">Optional; a placeholder will be used if empty</p>
         </FieldGroup>
         <FieldGroup label="LinkedIn URL (optional)">
           <InputBase type="url" value={form.linkedin} onChange={(e) => setForm(prev => ({ ...prev, linkedin: e.target.value }))} />
@@ -185,7 +185,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ open, editing, form, setForm, onC
               onBlur={handleYearsBlur}
               placeholder="e.g. 2025, 2026, 2027"
             />
-            <p className="text-xs text-gray-500 mt-1">Comma-separated years. Leave empty for "always visible".</p>
+            <p className="text-xs text-muted-foreground mt-1">Comma-separated years. Leave empty for "always visible".</p>
           </FieldGroup>
         </div>
 

--- a/components/pages/admin/tabs/AISettingsTab.tsx
+++ b/components/pages/admin/tabs/AISettingsTab.tsx
@@ -46,7 +46,14 @@ const AISettingsTab: React.FC = () => {
   const loadSettings = async () => {
     try {
       setLoading(true);
-      const data = await getAISettings();
+      // A degraded Firestore client (e.g. after a revoked permission) can make
+      // getDoc never settle — bound it so the tab can't hang in a spinner.
+      const data = await Promise.race([
+        getAISettings(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Timed out loading AI settings')), 8000)
+        ),
+      ]);
       setSettings(data);
     } catch (e) {
       console.error('Failed to load AI settings:', e);
@@ -198,14 +205,14 @@ Always base your recommendations on the provided course context.`,
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
   }
 
   if (!settings) {
     return (
-      <div className="text-center py-12 text-gray-600 dark:text-gray-300">
+      <div className="text-center py-12 text-muted-foreground">
         Failed to load AI settings
       </div>
     );
@@ -218,8 +225,8 @@ Always base your recommendations on the provided course context.`,
         <div className="flex items-center gap-3">
           <Bot className="h-6 w-6 text-primary" />
           <div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">AI Settings</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Configure the AI course advisor behavior and limits</p>
+            <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">AI Settings</h2>
+            <p className="text-sm text-muted-foreground">Configure the AI course advisor behavior and limits</p>
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -255,17 +262,17 @@ Always base your recommendations on the provided course context.`,
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center gap-2 mb-4">
-            <Settings2 className="h-5 w-5 text-gray-500" />
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white">System Prompt</h3>
+            <Settings2 className="h-5 w-5 text-muted-foreground" />
+            <h3 className="text-lg font-medium text-foreground">System Prompt</h3>
           </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          <p className="text-sm text-muted-foreground mb-4">
             This prompt guides the AI&apos;s behavior when responding to course queries. Changes apply immediately.
           </p>
           <textarea
             value={settings.systemPrompt}
             onChange={(e) => setSettings({ ...settings, systemPrompt: e.target.value })}
             rows={10}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent font-mono text-sm transition-colors duration-300"
+            className="w-full px-3 py-2 border border-border rounded-md bg-card text-foreground focus:ring-2 focus:ring-primary focus:border-transparent font-mono text-sm transition-colors duration-300"
           />
         </CardContent>
       </Card>
@@ -274,9 +281,9 @@ Always base your recommendations on the provided course context.`,
       <div className="grid md:grid-cols-2 gap-6">
         <Card>
           <CardContent className="p-6">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">API Provider</h3>
+            <h3 className="text-lg font-medium text-foreground mb-4">API Provider</h3>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
                 AI API Provider
               </label>
               <Select
@@ -296,7 +303,7 @@ Always base your recommendations on the provided course context.`,
         <Card>
           <CardContent className="p-6">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white">Model</h3>
+              <h3 className="text-lg font-medium text-foreground">Model</h3>
               {isSuperAdmin && settings.apiProvider === 'openrouter' && (
                 <Button
                   size="sm"
@@ -313,7 +320,7 @@ Always base your recommendations on the provided course context.`,
               )}
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
                 AI model (USD per 1M tokens)
               </label>
               <Select
@@ -327,7 +334,7 @@ Always base your recommendations on the provided course context.`,
                       { value: 'moonshot-v1-32k', label: 'moonshot-v1-32k' },
                     ]}
               />
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 {settings.apiProvider === 'openrouter' && openRouterModels.length > 0
                   ? `Loaded ${openRouterModels.length} models from OpenRouter`
                   : 'Only super admins can change the model'}
@@ -341,9 +348,9 @@ Always base your recommendations on the provided course context.`,
       <div className="grid md:grid-cols-2 gap-6">
         <Card>
           <CardContent className="p-6">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Cost</h3>
+            <h3 className="text-lg font-medium text-foreground mb-4">Cost</h3>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
                 Cost per 1k tokens (USD)
               </label>
               <Input
@@ -354,7 +361,7 @@ Always base your recommendations on the provided course context.`,
                 disabled={!isSuperAdmin}
                 onChange={(e) => setSettings({ ...settings, costPer1kTokensUsd: Number(e.target.value) || 0 })}
               />
-              <p className="text-xs text-gray-500 mt-1">Used for cost estimates in usage statistics</p>
+              <p className="text-xs text-muted-foreground mt-1">Used for cost estimates in usage statistics</p>
             </div>
           </CardContent>
         </Card>
@@ -364,10 +371,10 @@ Always base your recommendations on the provided course context.`,
       <div className="grid md:grid-cols-2 gap-6">
         <Card>
           <CardContent className="p-6">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Rate Limiting</h3>
+            <h3 className="text-lg font-medium text-foreground mb-4">Rate Limiting</h3>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label className="block text-sm font-medium text-foreground/80 mb-1">
                   Requests per day
                 </label>
                 <Input
@@ -377,10 +384,10 @@ Always base your recommendations on the provided course context.`,
                   value={settings.rateLimitRequestsPerDay}
                   onChange={(e) => setSettings({ ...settings, rateLimitRequestsPerDay: parseInt(e.target.value) || 10 })}
                 />
-                <p className="text-xs text-gray-500 mt-1">Maximum AI requests per user per day</p>
+                <p className="text-xs text-muted-foreground mt-1">Maximum AI requests per user per day</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label className="block text-sm font-medium text-foreground/80 mb-1">
                   Max tokens per request
                 </label>
                 <Input
@@ -391,7 +398,7 @@ Always base your recommendations on the provided course context.`,
                   value={settings.maxTokensPerRequest}
                   onChange={(e) => setSettings({ ...settings, maxTokensPerRequest: parseInt(e.target.value) || 1024 })}
                 />
-                <p className="text-xs text-gray-500 mt-1">Maximum tokens in AI response</p>
+                <p className="text-xs text-muted-foreground mt-1">Maximum tokens in AI response</p>
               </div>
             </div>
           </CardContent>
@@ -399,10 +406,10 @@ Always base your recommendations on the provided course context.`,
 
         <Card>
           <CardContent className="p-6">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">History Limits</h3>
+            <h3 className="text-lg font-medium text-foreground mb-4">History Limits</h3>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label className="block text-sm font-medium text-foreground/80 mb-1">
                   Max conversation history
                 </label>
                 <Input
@@ -412,10 +419,10 @@ Always base your recommendations on the provided course context.`,
                   value={settings.maxConversationHistory}
                   onChange={(e) => setSettings({ ...settings, maxConversationHistory: parseInt(e.target.value) || 4 })}
                 />
-                <p className="text-xs text-gray-500 mt-1">Messages to include in context for AI responses</p>
+                <p className="text-xs text-muted-foreground mt-1">Messages to include in context for AI responses</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label className="block text-sm font-medium text-foreground/80 mb-1">
                   Max stored chats per user
                 </label>
                 <Input
@@ -425,7 +432,7 @@ Always base your recommendations on the provided course context.`,
                   value={settings.maxStoredChatsPerUser}
                   onChange={(e) => setSettings({ ...settings, maxStoredChatsPerUser: parseInt(e.target.value) || 50 })}
                 />
-                <p className="text-xs text-gray-500 mt-1">Maximum chat history stored per user</p>
+                <p className="text-xs text-muted-foreground mt-1">Maximum chat history stored per user</p>
               </div>
             </div>
           </CardContent>
@@ -436,45 +443,45 @@ Always base your recommendations on the provided course context.`,
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center gap-2 mb-4">
-            <BarChart3 className="h-5 w-5 text-gray-500" />
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white">Usage Statistics</h3>
+            <BarChart3 className="h-5 w-5 text-muted-foreground" />
+            <h3 className="text-lg font-medium text-foreground">Usage Statistics</h3>
           </div>
           <div className="grid md:grid-cols-3 gap-4">
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-              <div className="text-2xl font-bold text-gray-900 dark:text-white">
+            <div className="bg-foreground/[0.04] rounded-lg p-4">
+              <div className="text-2xl font-bold text-foreground">
                 {usageLoading ? '…' : (usage ? usage.totalRequests : '--')}
               </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">Total AI requests today</div>
+              <div className="text-sm text-muted-foreground">Total AI requests today</div>
             </div>
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-              <div className="text-2xl font-bold text-gray-900 dark:text-white">
+            <div className="bg-foreground/[0.04] rounded-lg p-4">
+              <div className="text-2xl font-bold text-foreground">
                 {usageLoading ? '…' : (usage ? usage.activeUsers : '--')}
               </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">Active users today</div>
+              <div className="text-sm text-muted-foreground">Active users today</div>
             </div>
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-              <div className="text-2xl font-bold text-gray-900 dark:text-white">
+            <div className="bg-foreground/[0.04] rounded-lg p-4">
+              <div className="text-2xl font-bold text-foreground">
                 {usageLoading ? '…' : (usage ? usage.averageTokensPerRequest : '--')}
               </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">Average tokens per request</div>
+              <div className="text-sm text-muted-foreground">Average tokens per request</div>
             </div>
           </div>
 
           <div className="grid md:grid-cols-2 gap-4 mt-4">
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-              <div className="text-2xl font-bold text-gray-900 dark:text-white">
+            <div className="bg-foreground/[0.04] rounded-lg p-4">
+              <div className="text-2xl font-bold text-foreground">
                 {usageLoading ? '…' : (usage ? usage.totalTokens : '--')}
               </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">Total tokens today</div>
+              <div className="text-sm text-muted-foreground">Total tokens today</div>
             </div>
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-              <div className="text-2xl font-bold text-gray-900 dark:text-white">
+            <div className="bg-foreground/[0.04] rounded-lg p-4">
+              <div className="text-2xl font-bold text-foreground">
                 {usageLoading ? '…' : (usage ? `$${usage.estimatedCostUsd.toFixed(4)}` : '--')}
               </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">Estimated cost today (USD)</div>
+              <div className="text-sm text-muted-foreground">Estimated cost today (USD)</div>
             </div>
           </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+          <div className="text-xs text-muted-foreground mt-3">
             Using cost per 1k tokens: ${settings.costPer1kTokensUsd.toFixed(4)}
           </div>
           <div className="flex items-center gap-2 mt-4">
@@ -482,7 +489,7 @@ Always base your recommendations on the provided course context.`,
               Refresh
             </Button>
             {usage?.date && (
-              <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="text-sm text-muted-foreground">
                 Date: {usage.date}
               </div>
             )}
@@ -491,7 +498,7 @@ Always base your recommendations on the provided course context.`,
       </Card>
 
       {/* Last Updated */}
-      <div className="text-sm text-gray-500 dark:text-gray-400">
+      <div className="text-sm text-muted-foreground">
         Last updated: {settings.updatedAt ? new Date(settings.updatedAt).toLocaleString() : 'Never'}
         {settings.updatedBy && ` by ${settings.updatedBy}`}
       </div>

--- a/components/pages/admin/tabs/AnalyticsTab.tsx
+++ b/components/pages/admin/tabs/AnalyticsTab.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
-import { TrendingUp, Users, Calendar, FileText, BriefcaseBusiness, Bot, Flame, Menu, X } from "lucide-react";
+import React from "react";
 import { useAnalyticsData, type AnalyticsTabKey } from "./analytics/useAnalyticsData";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import dynamic from "next/dynamic";
@@ -14,155 +13,68 @@ const AnalyticsMembersTab = dynamic(() => import("./analytics/AnalyticsMembersTa
 const AnalyticsAITab = dynamic(() => import("./analytics/AnalyticsAITab"), { ssr: false });
 const AnalyticsFirebaseTab = dynamic(() => import("./analytics/AnalyticsFirebaseTab"), { ssr: false });
 
-const tabs: { key: AnalyticsTabKey; label: string; icon: React.FC<{ className?: string }> }[] = [
-  { key: "overview", label: "Summary", icon: TrendingUp },
-  { key: "events", label: "Events", icon: Calendar },
-  { key: "members", label: "Members", icon: Users },
-  { key: "newsletter", label: "Blog", icon: FileText },
-  { key: "jobs", label: "Jobs", icon: BriefcaseBusiness },
-  { key: "ai", label: "AI Assistant", icon: Bot },
-  { key: "firebase", label: "Firebase", icon: Flame },
-];
+interface AnalyticsTabProps {
+  activeSubtab: AnalyticsTabKey;
+  onSelectSubtab: (key: AnalyticsTabKey) => void;
+}
 
-const AnalyticsTab: React.FC = () => {
-  const d = useAnalyticsData();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const isMounted = useRef(false);
-
-  const selectTab = useCallback((key: AnalyticsTabKey) => {
-    d.setActiveSubtab(key);
-    setSidebarOpen(false);
-    menuButtonRef.current?.focus();
-  }, [d]);
-
-  useEffect(() => {
-    if (!isMounted.current) {
-      isMounted.current = true;
-      return;
-    }
-    if (!sidebarOpen) {
-      menuButtonRef.current?.focus();
-      return;
-    }
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setSidebarOpen(false);
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [sidebarOpen]);
+const AnalyticsTab: React.FC<AnalyticsTabProps> = ({ activeSubtab, onSelectSubtab }) => {
+  const d = useAnalyticsData(activeSubtab, onSelectSubtab);
 
   return (
-    <div className="relative">
-      {/* Mobile toggle bar */}
-      <div className="flex md:hidden items-center gap-2 mb-4">
-        <button
-          ref={menuButtonRef}
-          onClick={() => setSidebarOpen((prev) => !prev)}
-          className="p-2 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-          aria-label={sidebarOpen ? 'Close analytics menu' : 'Open analytics menu'}
-          aria-expanded={sidebarOpen}
-        >
-          <div className="relative h-5 w-5">
-            <Menu className={`absolute h-5 w-5 transition-all duration-300 ${sidebarOpen ? 'rotate-90 opacity-0 scale-75' : 'rotate-0 opacity-100 scale-100'}`} />
-            <X className={`absolute h-5 w-5 transition-all duration-300 ${sidebarOpen ? 'rotate-0 opacity-100 scale-100' : '-rotate-90 opacity-0 scale-75'}`} />
-          </div>
-        </button>
-        <h2 className="text-lg font-bold text-gray-900 dark:text-white">Analytics</h2>
-      </div>
-
-      <div className="relative">
-        {/* Mobile overlay */}
-        {sidebarOpen && (
-          <div className="absolute inset-0 z-40 bg-black/50 md:hidden rounded-lg" onClick={() => setSidebarOpen(false)} />
-        )}
-
-        <div className="flex gap-6">
-          <nav
-            className={`
-              w-44 shrink-0 space-y-1
-              absolute inset-y-0 left-0 z-40 bg-white dark:bg-gray-900 p-4 shadow-xl
-              transition-all duration-200 ease-in-out overflow-y-auto
-              ${sidebarOpen ? 'translate-x-0 visible pointer-events-auto' : '-translate-x-full invisible pointer-events-none'}
-              md:relative md:translate-x-0 md:visible md:pointer-events-auto md:shadow-none md:p-0 md:bg-transparent md:dark:bg-transparent md:z-0
-            `}
-            aria-label="Analytics sections"
-          >
-          {tabs.map(({ key, label, icon: Icon }) => (
-            <button
-              key={key}
-              onClick={() => selectTab(key)}
-              className={`cursor-pointer w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-all duration-200 ease-in-out ${
-                d.activeSubtab === key
-                  ? "bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400"
-                  : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-              }`}
-              aria-current={d.activeSubtab === key ? "page" : undefined}
-            >
-              <Icon className="h-4 w-4 shrink-0" />
-              <span className="truncate">{label}</span>
-            </button>
-          ))}
-          </nav>
-
-          <div className="flex-1 min-w-0">
-            <h2 className="hidden md:block text-lg font-bold text-gray-900 dark:text-white mb-4">Analytics</h2>
-          {d.activeSubtab === "overview" && (
-          <ErrorBoundary>
-            <AnalyticsOverviewTab
-              events={d.events}
-              blogs={d.blogs}
-              jobs={d.jobs}
-              teamMembers={d.teamMembers}
-              boardPositions={d.boardPositions}
-              applicants={d.applicants}
-              eventClicks={d.eventClicks}
-              blogReads={d.blogReads}
-              jobClicks={d.jobClicks}
-              memberAnalytics={d.memberAnalytics}
-              funnelData={d.funnelData}
-              aiAnalytics={d.aiAnalytics}
-              totalClicks={d.totalClicks}
-              totalBlogReads={d.totalBlogReads}
-              totalJobClicks={d.totalJobClicks}
-            />
-          </ErrorBoundary>
-        )}
-        {d.activeSubtab === "events" && (
-          <ErrorBoundary>
-            <AnalyticsEventsTab funnelData={d.funnelData} events={d.events} regAnalytics={d.regAnalytics} />
-          </ErrorBoundary>
-        )}
-        {d.activeSubtab === "members" && (
-          <ErrorBoundary>
-            <AnalyticsMembersTab memberAnalytics={d.memberAnalytics} chartData={d.chartData} eventMarkers={d.eventMarkers} />
-          </ErrorBoundary>
-        )}
-        {d.activeSubtab === "newsletter" && (
-          <ErrorBoundary>
-            <AnalyticsNewsletterTab blogs={d.blogs} blogReads={d.blogReads} />
-          </ErrorBoundary>
-        )}
-        {d.activeSubtab === "jobs" && (
-          <ErrorBoundary>
-            <AnalyticsJobsTab jobs={d.jobs} jobClicks={d.jobClicks} />
-          </ErrorBoundary>
-        )}
-        {d.activeSubtab === "ai" && (
-          <ErrorBoundary>
-            <AnalyticsAITab aiAnalytics={d.aiAnalytics} />
-          </ErrorBoundary>
-        )}
-        {d.activeSubtab === "firebase" && (
-          <ErrorBoundary>
-            <AnalyticsFirebaseTab firebaseData={d.firebaseData} firebaseLoading={d.firebaseLoading} />
-          </ErrorBoundary>
-        )}
-          </div>
-        </div>
-      </div>
+    <div>
+      <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground mb-4">Analytics</h2>
+      {activeSubtab === "overview" && (
+        <ErrorBoundary>
+          <AnalyticsOverviewTab
+            events={d.events}
+            blogs={d.blogs}
+            jobs={d.jobs}
+            teamMembers={d.teamMembers}
+            boardPositions={d.boardPositions}
+            applicants={d.applicants}
+            eventClicks={d.eventClicks}
+            blogReads={d.blogReads}
+            jobClicks={d.jobClicks}
+            memberAnalytics={d.memberAnalytics}
+            funnelData={d.funnelData}
+            aiAnalytics={d.aiAnalytics}
+            totalClicks={d.totalClicks}
+            totalBlogReads={d.totalBlogReads}
+            totalJobClicks={d.totalJobClicks}
+          />
+        </ErrorBoundary>
+      )}
+      {activeSubtab === "events" && (
+        <ErrorBoundary>
+          <AnalyticsEventsTab funnelData={d.funnelData} events={d.events} regAnalytics={d.regAnalytics} />
+        </ErrorBoundary>
+      )}
+      {activeSubtab === "members" && (
+        <ErrorBoundary>
+          <AnalyticsMembersTab memberAnalytics={d.memberAnalytics} chartData={d.chartData} eventMarkers={d.eventMarkers} />
+        </ErrorBoundary>
+      )}
+      {activeSubtab === "newsletter" && (
+        <ErrorBoundary>
+          <AnalyticsNewsletterTab blogs={d.blogs} blogReads={d.blogReads} />
+        </ErrorBoundary>
+      )}
+      {activeSubtab === "jobs" && (
+        <ErrorBoundary>
+          <AnalyticsJobsTab jobs={d.jobs} jobClicks={d.jobClicks} />
+        </ErrorBoundary>
+      )}
+      {activeSubtab === "ai" && (
+        <ErrorBoundary>
+          <AnalyticsAITab aiAnalytics={d.aiAnalytics} />
+        </ErrorBoundary>
+      )}
+      {activeSubtab === "firebase" && (
+        <ErrorBoundary>
+          <AnalyticsFirebaseTab firebaseData={d.firebaseData} firebaseLoading={d.firebaseLoading} />
+        </ErrorBoundary>
+      )}
     </div>
   );
 };

--- a/components/pages/admin/tabs/ApplicationsTab.tsx
+++ b/components/pages/admin/tabs/ApplicationsTab.tsx
@@ -11,8 +11,17 @@ import { Card } from "@/components/ui/Card";
 import Tag from "@/components/ui/Tag";
 import { InputBase, SelectBase } from "@/components/ui/Form";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import CampaignBuilderModal from "@/components/pages/admin/modals/CampaignBuilderModal";
 import { subscribeToCampaignQuestions } from "@/lib/firestore/campaignQuestions";
 import { exportApplicationsZip } from "@/lib/exportApplications";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
+import {
+  subscribeAllCampaigns, addCampaign, updateCampaign, deleteCampaign,
+} from "@/lib/firestore/applicationCampaigns";
+import { deleteCampaignQuestionsByCampaign } from "@/lib/firestore/campaignQuestions";
+import { subscribeToTeamApplications } from "@/lib/firestore/teamApplications";
+import { deleteTeamApplicationWithLimits } from "@/lib/firestore/teamApplications";
+import { useNotify } from "@/components/ui/Notifications";
 import {
   ApplicationCampaign, TeamApplication, CampaignStatus,
 } from "@/types";
@@ -59,19 +68,10 @@ function safeUrl(url: string | null | undefined): string | undefined {
   return undefined;
 }
 
-interface ApplicationsTabProps {
-  campaigns: ApplicationCampaign[];
-  applications: TeamApplication[];
-  onAddCampaign: () => void;
-  onEditCampaign: (campaign: ApplicationCampaign) => void;
-  onDeleteCampaign: (id: string) => void;
-  onUpdateCampaignStatus: (id: string, status: CampaignStatus) => void;
-  onDeleteApplication: (id: string, emailNormalized: string, campaignId: string) => void;
-}
-
-const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
-  campaigns, applications, onAddCampaign, onEditCampaign, onDeleteCampaign, onUpdateCampaignStatus, onDeleteApplication,
-}) => {
+const ApplicationsTab: React.FC = () => {
+  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeAllCampaigns, []);
+  const { data: applications, loaded: applicationsLoaded } = useCollectionData<TeamApplication>(subscribeToTeamApplications, []);
+  const { notify } = useNotify();
   const [filter, setFilter] = useState<"all" | CampaignStatus>("all");
   const [view, setView] = useState<"campaigns" | "submissions">("campaigns");
   const [selectedCampaign, setSelectedCampaign] = useState<ApplicationCampaign | null>(null);
@@ -82,6 +82,8 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
   const [confirmDeleteApp, setConfirmDeleteApp] = useState<TeamApplication | null>(null);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [showCampaignModal, setShowCampaignModal] = useState(false);
+  const [editingCampaign, setEditingCampaign] = useState<ApplicationCampaign | null>(null);
 
   // Load the selected campaign's questions so admins see readable labels for
   // custom answers (falls back to the raw question id while loading).
@@ -179,6 +181,45 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
     }
   };
 
+  const handleSaveCampaign = async (data: { id?: string; title: string; subtitle: string; description: string; deadline: string; status: CampaignStatus; teams: string[]; roles: ApplicationCampaign["roles"]; teamInfo?: Record<string, { name?: string; description?: string }>; enabledStandardFields: string[] }): Promise<string | undefined> => {
+    if (data.id) {
+      await updateCampaign(data.id, { title: data.title, subtitle: data.subtitle, description: data.description, deadline: data.deadline, status: data.status, teams: data.teams, roles: data.roles, teamInfo: data.teamInfo, enabledStandardFields: data.enabledStandardFields });
+      return data.id;
+    }
+    const id = await addCampaign({ title: data.title, subtitle: data.subtitle, description: data.description, deadline: data.deadline, status: data.status, teams: data.teams, roles: data.roles, teamInfo: data.teamInfo, enabledStandardFields: data.enabledStandardFields });
+    return id;
+  };
+
+  const handleDeleteCampaign = (id: string) => {
+    if (window.confirm("Delete this campaign and all its custom questions? Submissions will remain in Firestore.")) {
+      deleteCampaign(id)
+        .then(() => deleteCampaignQuestionsByCampaign(id))
+        .then(() => notify({ type: "success", title: "Campaign deleted", message: "The campaign was removed." }))
+        .catch((e) => {
+          console.error("Failed to delete campaign:", e);
+          notify({ type: "error", title: "Delete failed", message: "Could not delete the campaign. Please try again." });
+        });
+    }
+  };
+
+  const handleDeleteTeamApplication = (id: string, emailNormalized: string, campaignId: string) => {
+    if (window.confirm("Delete this submission?")) {
+      deleteTeamApplicationWithLimits(id, emailNormalized, campaignId)
+        .then(() => notify({ type: "success", title: "Submission deleted", message: "The submission was removed." }))
+        .catch((e) => {
+          console.error("Failed to delete submission:", e);
+          notify({ type: "error", title: "Delete failed", message: "Could not delete the submission. Please try again." });
+        });
+    }
+  };
+
+  const handleUpdateStatus = (id: string, status: CampaignStatus) => {
+    updateCampaign(id, { status }).catch((e) => {
+      console.error("Failed to update status:", e);
+      notify({ type: "error", title: "Update failed", message: "Could not change the campaign status. Please try again." });
+    });
+  };
+
   const renderRoleTags = (submission: TeamApplication) => {
     if (submission.roleRanking && submission.roleRanking.length > 0) {
       return submission.roleRanking.slice(0, 3).map((c, idx) => (
@@ -196,10 +237,10 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
         <div className="flex items-center gap-3 mb-6">
           <Button size="sm" variant="outline" icon={ArrowLeft} onClick={() => { setView("campaigns"); setSelectedCampaign(null); }}>Back to campaigns</Button>
           <div className="flex-1 min-w-0">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">
               {selectedCampaign ? `Submissions: ${selectedCampaign.title}` : "All Submissions"}
             </h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 flex items-center gap-3">
+            <p className="text-sm text-muted-foreground mt-1 flex items-center gap-3">
               <span className="flex items-center gap-1"><Users className="h-3.5 w-3.5" /> {filteredSubs.length} of {campaignSubs.length}</span>
               {selectedCampaign && <span>· Deadline {selectedCampaign.deadline}</span>}
             </p>
@@ -208,17 +249,17 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
             <Button size="sm" variant="outline" icon={Download} isLoading={exporting} disabled={filteredSubs.length === 0} onClick={handleExportZip}>
               Export .zip
             </Button>
-            {exportError && <span className="text-xs text-red-600 dark:text-red-400">{exportError}</span>}
+            {exportError && <span className="text-xs text-destructive">{exportError}</span>}
           </div>
         </div>
 
         <div className="flex flex-col sm:flex-row gap-3 mb-6">
           <div className="relative flex-1 max-w-md">
-            <Search className="h-4 w-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" />
+            <Search className="h-4 w-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2" />
             <InputBase placeholder="Search by name, email, or program..." aria-label="Search submissions" value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
           </div>
           <div className="flex items-center gap-2">
-            <label htmlFor="applications-role-filter" className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">Filter by role:</label>
+            <label htmlFor="applications-role-filter" className="text-sm text-muted-foreground whitespace-nowrap">Filter by role:</label>
             <SelectBase
               id="applications-role-filter"
               value={subFilter}
@@ -237,24 +278,26 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
           </div>
         </div>
 
-        <div className="grid gap-3">
-          {filteredSubs.length === 0 ? (
-            <div className="text-center py-16 text-gray-500 dark:text-gray-400">No submissions match your filters.</div>
-          ) : (
+      <div className="grid gap-3">
+        {!applicationsLoaded ? (
+          <p className="mono-label text-muted-foreground py-6">Loading…</p>
+        ) : filteredSubs.length === 0 ? (
+          <div className="text-center py-16 text-muted-foreground">No submissions match your filters.</div>
+        ) : (
             filteredSubs.map((submission) => {
               const isOpen = expandApp.has(submission.id);
               return (
-                <Card key={submission.id} className="bg-white dark:bg-gray-800">
+                <Card key={submission.id}>
                   <div className="p-5">
                     <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
                       <div className="flex-1 min-w-0">
                         <button onClick={() => toggleApp(submission.id)} aria-expanded={isOpen} aria-controls={`submission-details-${submission.id}`} className="flex items-center gap-2 text-left group transition-all duration-300 ease-in-out cursor-pointer">
-                          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{submission.name}</h3>
+                          <h3 className="text-lg font-semibold text-foreground">{submission.name}</h3>
                           {isOpen
-                            ? <ChevronUp className="h-4 w-4 text-gray-400 group-hover:text-gray-600 transition-colors" />
-                            : <ChevronDown className="h-4 w-4 text-gray-400 group-hover:text-gray-600 transition-colors" />}
+                            ? <ChevronUp className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+                            : <ChevronDown className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />}
                         </button>
-                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-muted-foreground">
                           <span className="flex items-center gap-1"><Mail className="h-3.5 w-3.5" /> {submission.email}</span>
                           <span className="flex items-center gap-1"><Calendar className="h-3.5 w-3.5" /> {formatDate(submission.createdAt)}</span>
                         </div>
@@ -271,29 +314,29 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                     </div>
                     <div id={`submission-details-${submission.id}`} inert={!isOpen} className={`grid overflow-hidden transition-all duration-500 ease-in-out ${isOpen ? "mt-4 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}>
                       <div className="min-h-0">
-                        <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-3">
+                        <div className="border-t border-border pt-4 space-y-3">
                           {submission.linkedin && (
                             <div className="text-sm">
-                              <span className="text-xs font-medium text-gray-500 uppercase mr-2">LinkedIn</span>
-                              <a href={safeUrl(submission.linkedin) || "#"} target="_blank" rel="noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1">
+                              <span className="mono-label text-muted-foreground mr-2">LinkedIn</span>
+                              <a href={safeUrl(submission.linkedin) || "#"} target="_blank" rel="noreferrer" className="text-primary hover:brightness-110 hover:underline inline-flex items-center gap-1">
                                 {submission.linkedin} <ExternalLink className="h-3 w-3" />
                               </a>
                             </div>
                           )}
                           {submission.resume?.url && (
                             <div className="text-sm">
-                              <span className="text-xs font-medium text-gray-500 uppercase mr-2">Resume</span>
-                              <a href={safeUrl(submission.resume.url) || "#"} target="_blank" rel="noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">View PDF</a>
+                              <span className="mono-label text-muted-foreground mr-2">Resume</span>
+                              <a href={safeUrl(submission.resume.url) || "#"} target="_blank" rel="noreferrer" className="text-primary hover:brightness-110 hover:underline">View PDF</a>
                             </div>
                           )}
                           {(submission.roleRanking && submission.roleRanking.length > 0) && (
                             <div>
-                              <span className="block text-xs font-medium text-gray-500 uppercase mb-2">Role preferences</span>
+                              <span className="mono-label text-muted-foreground block mb-2">Role preferences</span>
                               <div className="space-y-3">
                                 {submission.roleRanking.map((c, idx) => (
                                   <div key={c.roleId}>
-                                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                      #{idx + 1} {roleTitle(c.roleId)} <span className="text-gray-400">· {teamName(c.teamId)}</span>
+                                    <span className="text-sm font-medium text-foreground/80">
+                                      #{idx + 1} {roleTitle(c.roleId)} <span className="text-muted-foreground">· {teamName(c.teamId)}</span>
                                     </span>
                                   </div>
                                 ))}
@@ -302,27 +345,27 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                           )}
                           {submission.customRole && (
                             <div className="text-sm">
-                              <span className="text-xs font-medium text-gray-500 uppercase mr-2">Proposed role</span>
-                              <span className="text-gray-700 dark:text-gray-300">{submission.customRole}</span>
+                              <span className="mono-label text-muted-foreground mr-2">Proposed role</span>
+                              <span className="text-foreground/80">{submission.customRole}</span>
                             </div>
                           )}
                           {submission.motivation && (
                             <div>
-                              <span className="block text-xs font-medium text-gray-500 uppercase mb-1">Motivation</span>
-                              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words border-l-2 border-gray-300 dark:border-gray-600 pl-3">{submission.motivation}</p>
+                              <span className="mono-label text-muted-foreground block mb-1">Motivation</span>
+                              <p className="text-sm text-foreground/80 whitespace-pre-wrap break-words border-l border-border pl-3">{submission.motivation}</p>
                             </div>
                           )}
                           {submission.customAnswers && Object.keys(submission.customAnswers).length > 0 && (
-                            <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
-                              <span className="block text-xs font-medium text-gray-500 uppercase mb-2">Custom answers</span>
+                            <div className="pt-2 border-t border-border">
+                              <span className="mono-label text-muted-foreground block mb-2">Custom answers</span>
                               <div className="space-y-2">
                                 {Object.entries(submission.customAnswers).map(([k, v]) => {
                                   const display = Array.isArray(v) ? v.join(", ") : v;
                                   const label = questionMap?.get(k) || k;
                                   return (
                                     <div key={k}>
-                                      <span className="text-xs font-medium text-gray-600 dark:text-gray-400">{label}</span>
-                                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-0.5">{display || <span className="italic text-gray-400">No answer</span>}</p>
+                                      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+                                      <p className="text-sm text-foreground/80 mt-0.5">{display || <span className="italic text-muted-foreground">No answer</span>}</p>
                                     </div>
                                   );
                                 })}
@@ -345,7 +388,7 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
           description={`This will permanently delete the submission from ${confirmDeleteApp?.name || "this applicant"}.`}
           confirmText="Delete"
           onClose={() => setConfirmDeleteApp(null)}
-          onConfirm={async () => { if (confirmDeleteApp) onDeleteApplication(confirmDeleteApp.id, confirmDeleteApp.emailNormalized || confirmDeleteApp.email.toLowerCase(), confirmDeleteApp.campaignId); setConfirmDeleteApp(null); }}
+          onConfirm={async () => { if (confirmDeleteApp) handleDeleteTeamApplication(confirmDeleteApp.id, confirmDeleteApp.emailNormalized || confirmDeleteApp.email.toLowerCase(), confirmDeleteApp.campaignId); setConfirmDeleteApp(null); }}
         />
       </div>
     );
@@ -356,15 +399,15 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
     <div key="campaigns" className="animate-in fade-in slide-in-from-right-4 duration-300 ease-out">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Application Campaigns</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Applications</h2>
+          <p className="text-sm text-muted-foreground mt-1">
             Create and manage recruitment campaigns. Each campaign has its own roles, form, deadline, and submissions.
           </p>
         </div>
-        <Button variant="outline" icon={Plus} onClick={onAddCampaign}>New campaign</Button>
+        <Button variant="outline" icon={Plus} onClick={() => { setEditingCampaign(null); setShowCampaignModal(true); }}>New campaign</Button>
       </div>
 
-      <div className="flex items-center gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center gap-1 mb-6 border-b border-border">
         {(["all", "open", "closed", "draft"] as const).map((f) => {
           const isActive = filter === f;
           const label = f === "all" ? "All" : STATUS_STYLES[f].label;
@@ -372,13 +415,13 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
             <button
               key={f}
               onClick={() => setFilter(f)}
-              className={`px-4 py-2 text-sm font-medium border-b-2 transition-all duration-200 ${
-                isActive ? "border-red-600 text-red-600 dark:text-red-400" : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-all duration-200 cursor-pointer ${
+                isActive ? "border-primary text-primary" : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
               }`}
             >
               {label}
               <span className={`ml-2 inline-flex items-center justify-center text-xs rounded-full px-1.5 ${
-                isActive ? "bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400" : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                isActive ? "bg-primary/10 text-primary" : "bg-foreground/[0.06] text-muted-foreground"
               }`}>{counts[f]}</span>
             </button>
           );
@@ -386,8 +429,10 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
       </div>
 
       <div className="grid gap-4">
-        {filtered.length === 0 ? (
-          <div className="text-center py-16 text-gray-500 dark:text-gray-400">
+        {!campaignsLoaded ? (
+          <p className="mono-label text-muted-foreground py-6">Loading…</p>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-16 text-muted-foreground">
             No campaigns with status &ldquo;{filter !== "all" ? STATUS_STYLES[filter].label : "all"}&rdquo;.
           </div>
         ) : (
@@ -395,16 +440,16 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
             const subCount = applications.filter((s) => s.campaignId === c.id).length;
             const roleCount = c.roles?.length || 0;
             return (
-              <Card key={c.id} className="bg-white dark:bg-gray-800">
+              <Card key={c.id}>
                 <div className="p-5">
                   <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
                     <div className="flex-1 min-w-0">
                       <div className="flex flex-wrap items-center gap-2 mb-2">
-                        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{c.title}</h2>
+                        <h2 className="text-lg font-semibold text-foreground">{c.title}</h2>
                         <div
                           role="group"
                           aria-label={`Status for ${c.title}`}
-                          className="relative inline-flex items-center rounded-full border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-0.5"
+                          className="relative inline-flex items-center rounded-full border border-border bg-foreground/[0.04] p-0.5"
                         >
                           <span
                             aria-hidden
@@ -415,12 +460,12 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                             <button
                               key={s}
                               type="button"
-                              onClick={() => onUpdateCampaignStatus(c.id, s)}
+                              onClick={() => handleUpdateStatus(c.id, s)}
                               aria-pressed={c.status === s}
                               className={`relative z-10 flex-1 px-2.5 py-1 text-xs font-medium rounded-full transition-all duration-300 cursor-pointer ${
                                 c.status === s
                                   ? "text-white"
-                                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                                  : "text-muted-foreground hover:text-foreground"
                               }`}
                             >
                               {STATUS_STYLES[s].label}
@@ -428,8 +473,8 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                           ))}
                         </div>
                       </div>
-                      <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{c.subtitle} · {c.description}</p>
-                      <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-sm text-muted-foreground mb-3">{c.subtitle} · {c.description}</p>
+                      <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
                         <span className="flex items-center gap-1"><Calendar className="h-3.5 w-3.5" /> Deadline {c.deadline}</span>
                         <span className="flex items-center gap-1"><Users className="h-3.5 w-3.5" /> {subCount} submission{subCount !== 1 ? "s" : ""}</span>
                         <span className="flex items-center gap-1"><FileQuestion className="h-3.5 w-3.5" /> {roleCount} role{roleCount !== 1 ? "s" : ""}</span>
@@ -439,7 +484,7 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
                       {subCount > 0 && (
                         <Button size="sm" variant="outline" icon={Eye} onClick={() => { setSelectedCampaign(c); setView("submissions"); }}>View submissions</Button>
                       )}
-                      <Button size="sm" variant="outline" icon={Edit3} onClick={() => onEditCampaign(c)}>Edit</Button>
+                      <Button size="sm" variant="outline" icon={Edit3} onClick={() => { setEditingCampaign(c); setShowCampaignModal(true); }}>Edit</Button>
                       <Button size="sm" variant="destructive" icon={Trash2} onClick={() => setConfirmDeleteCampaign(c)}>
                         <span className="sr-only">Delete campaign</span>
                       </Button>
@@ -452,13 +497,21 @@ const ApplicationsTab: React.FC<ApplicationsTabProps> = ({
         )}
       </div>
 
+      <CampaignBuilderModal
+        open={showCampaignModal}
+        campaign={editingCampaign}
+        isNew={!editingCampaign}
+        onClose={() => { setShowCampaignModal(false); setEditingCampaign(null); }}
+        onSaveCampaign={handleSaveCampaign}
+      />
+
       <ConfirmModal
         open={!!confirmDeleteCampaign}
         title="Delete campaign?"
         description={`This will permanently delete "${confirmDeleteCampaign?.title}" and all its custom questions. Submissions will remain in Firestore.`}
         confirmText="Delete"
         onClose={() => setConfirmDeleteCampaign(null)}
-        onConfirm={async () => { if (confirmDeleteCampaign) onDeleteCampaign(confirmDeleteCampaign.id); setConfirmDeleteCampaign(null); }}
+        onConfirm={async () => { if (confirmDeleteCampaign) handleDeleteCampaign(confirmDeleteCampaign.id); setConfirmDeleteCampaign(null); }}
       />
     </div>
   );

--- a/components/pages/admin/tabs/BlogAISettingsTab.tsx
+++ b/components/pages/admin/tabs/BlogAISettingsTab.tsx
@@ -112,7 +112,13 @@ const BlogAISettingsTab: React.FC = () => {
   const loadSettings = async () => {
     try {
       setLoading(true);
-      const data = await getBlogAISettings();
+      // A degraded Firestore client can make getDoc never settle; bound it so the tab can't hang in a spinner.
+      const data = await Promise.race([
+        getBlogAISettings(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Timed out loading blog AI settings')), 8000)
+        ),
+      ]);
       setSettings(data);
       setFeedsText(serializeFeeds(data.feeds));
     } catch (e) {

--- a/components/pages/admin/tabs/BlogAISettingsTab.tsx
+++ b/components/pages/admin/tabs/BlogAISettingsTab.tsx
@@ -216,7 +216,7 @@ const BlogAISettingsTab: React.FC = () => {
         <div className="flex items-center gap-3">
           <Bot className="h-6 w-6 text-primary" />
           <div>
-            <h2 className="text-xl font-semibold text-foreground">AI News Desk Settings</h2>
+            <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">AI News Desk</h2>
             <p className="text-sm text-muted-foreground">Configure the blog generation model, prompts, and news sources</p>
           </div>
         </div>

--- a/components/pages/admin/tabs/BlogTab.tsx
+++ b/components/pages/admin/tabs/BlogTab.tsx
@@ -7,16 +7,11 @@ import { Card, CardContent } from "@/components/ui/Card";
 import { BlogPost } from "@/types";
 import { Edit3, Eye, EyeOff, Plus, Sparkles, Trash2, User, Calendar, Star } from "lucide-react";
 import Tag from "@/components/ui/Tag";
-
-export interface BlogTabProps {
-  posts: BlogPost[];
-  onAddClick: () => void;
-  onGenerateClick?: () => void;
-  onEdit: (post: BlogPost) => void;
-  onDelete: (id: string) => void;
-  onTogglePublish: (post: BlogPost) => void;
-  onToggleFeatured?: (post: BlogPost) => void;
-}
+import BlogModal, { type BlogFormState } from "@/components/pages/admin/modals/BlogModal";
+import GenerateBlogModal from "@/components/pages/admin/modals/GenerateBlogModal";
+import { useApp } from "@/contexts/AppContext";
+import { addUsedNewsUrls, removeUsedNewsUrls } from "@/lib/firestore/blog-seen";
+import { auth } from "@/lib/firebase-client";
 
 type BlogSection = "all" | "team" | "ai";
 
@@ -26,8 +21,26 @@ const SECTIONS: { key: BlogSection; label: string }[] = [
   { key: "ai", label: "AI News Desk" },
 ];
 
-const BlogTab: React.FC<BlogTabProps> = ({ posts, onAddClick, onGenerateClick, onEdit, onDelete, onTogglePublish, onToggleFeatured }) => {
+const emptyForm: BlogFormState = {
+  title: "",
+  excerpt: "",
+  content: "",
+  author: "",
+  image: "",
+  tags: [],
+  published: false,
+};
+
+const BlogTab: React.FC = () => {
+  const { state, dispatch } = useApp();
+  const posts = state.blogPosts;
   const [section, setSection] = useState<BlogSection>("all");
+  const [showBlogModal, setShowBlogModal] = useState(false);
+  const [showGenerateBlogModal, setShowGenerateBlogModal] = useState(false);
+  const [editingItem, setEditingItem] = useState<BlogPost | null>(null);
+  const [blogForm, setBlogForm] = useState<BlogFormState>(emptyForm);
+
+  const placeholderImage = "/images/logo-highdef.png";
 
   const filteredPosts = section === "all"
     ? posts
@@ -35,15 +48,105 @@ const BlogTab: React.FC<BlogTabProps> = ({ posts, onAddClick, onGenerateClick, o
       ? posts.filter((p) => p.authorType !== "ai")
       : posts.filter((p) => p.authorType === "ai");
 
+  const resetForms = () => {
+    setBlogForm(emptyForm);
+    setEditingItem(null);
+  };
+
+  const reviewerName = () => auth.currentUser?.displayName || auth.currentUser?.email || "";
+
+  // Seen-URL lifecycle: cited sources become "covered" at publish and are released on unpublish/delete.
+  const syncSeenUrlsForPost = (post: BlogPost) => {
+    const urls = (post.sources ?? []).map((s) => s.url).filter(Boolean);
+    if (urls.length === 0) return;
+    if (post.published) {
+      addUsedNewsUrls(urls).catch((e) => console.warn("Failed to mark post sources as used:", e));
+    } else {
+      removeUsedNewsUrls(urls).catch((e) => console.warn("Failed to release post sources:", e));
+    }
+  };
+
+  const handleAddBlogPost = () => {
+    const newPost = {
+      ...blogForm,
+      image: blogForm.image || placeholderImage,
+      date: new Date().toISOString().split("T")[0]
+    } as BlogPost;
+    if (newPost.published && newPost.authorType === "ai" && !newPost.reviewedBy) {
+      newPost.reviewedBy = reviewerName();
+    }
+    dispatch({ firestoreAction: "ADD_BLOG_POST", payload: newPost });
+    syncSeenUrlsForPost(newPost);
+    setShowBlogModal(false);
+    resetForms();
+  };
+
+  const handleEditBlogPost = (post: BlogPost) => {
+    setEditingItem(post);
+    setBlogForm({
+      title: post.title,
+      excerpt: post.excerpt,
+      content: post.content,
+      author: post.author,
+      image: post.image,
+      tags: post.tags,
+      published: post.published
+    });
+    setShowBlogModal(true);
+  };
+
+  const handleUpdateBlogPost = () => {
+    if (editingItem) {
+      const updatedPost = { ...editingItem, ...blogForm } as BlogPost;
+      if (updatedPost.published && updatedPost.authorType === "ai" && !updatedPost.reviewedBy) {
+        updatedPost.reviewedBy = reviewerName();
+      }
+      dispatch({ firestoreAction: "UPDATE_BLOG_POST", payload: updatedPost });
+      syncSeenUrlsForPost(updatedPost);
+      setShowBlogModal(false);
+      resetForms();
+    }
+  };
+
+  const handleDeleteBlogPost = (postId: string) => {
+    if (window.confirm("Are you sure you want to delete this blog post?")) {
+      dispatch({ firestoreAction: "DELETE_BLOG_POST", payload: postId });
+    }
+  };
+
+  const toggleBlogPostVisibility = (post: BlogPost) => {
+    const payload: BlogPost = { ...post, published: !post.published };
+    if (payload.published && post.authorType === "ai" && !post.reviewedBy) {
+      payload.reviewedBy = reviewerName();
+    }
+    dispatch({ firestoreAction: "UPDATE_BLOG_POST", payload });
+    syncSeenUrlsForPost(payload);
+  };
+
+  const toggleBlogPostFeatured = (post: BlogPost) => {
+    dispatch({ firestoreAction: "UPDATE_BLOG_POST", payload: { ...post, featured: !post.featured } });
+  };
+
+  const handleDraftCreated = async (draftId: string) => {
+    setShowGenerateBlogModal(false);
+    try {
+      const mod = await import("@/lib/firestore/blog");
+      const post = await mod.getBlogPostById(draftId);
+      if (post) {
+        handleEditBlogPost(post);
+      }
+    } catch (e) {
+      console.error("Failed to load generated draft:", e);
+    }
+  };
+
   return (
     <div>
       <div className="flex flex-wrap justify-between items-center gap-3 mb-6">
-        <h2 className="text-2xl font-bold text-foreground">Blog Management</h2>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Blog</h2>
         <div className="flex flex-wrap gap-3">
-          {onGenerateClick && (
-            <Button variant="outline" icon={Sparkles} onClick={onGenerateClick}>Generate AI Draft</Button>
-          )}
-          <Button variant="outline" icon={Plus} onClick={onAddClick}>New Article</Button>
+          <Button variant="outline" icon={Sparkles} onClick={() => setShowGenerateBlogModal(true)}>Generate AI Draft</Button>
+          <Button variant="outline" icon={Plus} onClick={() => { resetForms(); setShowBlogModal(true); }}>New Article</Button>
         </div>
       </div>
 
@@ -108,31 +211,29 @@ const BlogTab: React.FC<BlogTabProps> = ({ posts, onAddClick, onGenerateClick, o
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-2 ml-4">
-                  {onToggleFeatured && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      icon={Star}
-                      className={post.featured ? "text-primary [&>svg]:fill-primary" : ""}
-                      onClick={() => onToggleFeatured(post)}
-                      aria-label={post.featured ? 'Unset featured' : 'Set featured'}
-                      aria-pressed={post.featured}
-                      title={post.featured ? 'Remove from featured' : 'Feature this article'}
-                    >
-                      {post.featured ? 'Featured' : 'Feature'}
-                    </Button>
-                  )}
-                  <Button size="sm" variant="outline" icon={post.published ? EyeOff : Eye} onClick={() => onTogglePublish(post)}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    icon={Star}
+                    className={post.featured ? "text-primary [&>svg]:fill-primary" : ""}
+                    onClick={() => toggleBlogPostFeatured(post)}
+                    aria-label={post.featured ? 'Unset featured' : 'Set featured'}
+                    aria-pressed={post.featured}
+                    title={post.featured ? 'Remove from featured' : 'Feature this article'}
+                  >
+                    {post.featured ? 'Featured' : 'Feature'}
+                  </Button>
+                  <Button size="sm" variant="outline" icon={post.published ? EyeOff : Eye} onClick={() => toggleBlogPostVisibility(post)}>
                     {post.published ? 'Unpublish' : 'Publish'}
                   </Button>
-                  <Button size="sm" variant="outline" icon={Edit3} onClick={() => onEdit(post)}>
+                  <Button size="sm" variant="outline" icon={Edit3} onClick={() => handleEditBlogPost(post)}>
                     Edit
                   </Button>
-                  <Button 
-                    size="sm" 
-                    variant="destructive" 
-                    icon={Trash2} 
-                    onClick={() => onDelete(post.id)} 
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    icon={Trash2}
+                    onClick={() => handleDeleteBlogPost(post.id)}
                   >
                     Delete
                   </Button>
@@ -142,6 +243,27 @@ const BlogTab: React.FC<BlogTabProps> = ({ posts, onAddClick, onGenerateClick, o
           </Card>
         ))}
       </div>
+
+      <BlogModal
+        open={showBlogModal}
+        editing={!!editingItem}
+        form={blogForm}
+        setForm={setBlogForm}
+        onClose={() => { setShowBlogModal(false); resetForms(); }}
+        onSubmit={() => {
+          if (editingItem) {
+            handleUpdateBlogPost();
+          } else {
+            handleAddBlogPost();
+          }
+        }}
+      />
+
+      <GenerateBlogModal
+        open={showGenerateBlogModal}
+        onClose={() => setShowGenerateBlogModal(false)}
+        onDraftCreated={handleDraftCreated}
+      />
     </div>
   );
 };

--- a/components/pages/admin/tabs/BoardTab.tsx
+++ b/components/pages/admin/tabs/BoardTab.tsx
@@ -2,9 +2,10 @@
 
 import React, { useState } from "react";
 import { Button } from "@/components/ui/Button";
-import { BoardPosition, Application } from "@/types";
+import { BoardPosition } from "@/types";
+import { subscribeToBoardApplications, deleteBoardApplication, type BoardApplication } from "@/lib/firestore/boardApplications";
 
-function formatApplicationDate(createdAt: Application["createdAt"]): string {
+function formatApplicationDate(createdAt: BoardApplication["createdAt"]): string {
   if (createdAt == null) return "—";
   if (typeof createdAt === "string") {
     const d = new Date(createdAt);
@@ -15,30 +16,23 @@ function formatApplicationDate(createdAt: Application["createdAt"]): string {
 import { Card, CardContent } from "@/components/ui/Card";
 import { Edit3, Plus, Trash2, ChevronDown, ChevronUp, ArrowUp, ArrowDown } from "lucide-react";
 import Link from "next/link";
+import BoardPositionModal, { type BPositionFormState } from "@/components/pages/admin/modals/BoardPositionModal";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
+import { subscribeToPositions, addPosition, updatePosition, deletePosition, movePosition } from "@/lib/firestore/board-positions";
+import { useNotify } from "@/components/ui/Notifications";
 
-export interface ApplicationProps {
-  applicants: Application[];
-  boardPositions: BoardPosition[];
-  onAddClick: () => void;
-  onEdit: (position: BoardPosition) => void;
-  onDeletePosition: (id: string) => void;
-  onDeleteApplicant: (id: string) => void;
-  onMovePosition: (positionId: string, direction: 'up' | 'down') => void;
-}
-
-const BoardTab: React.FC<ApplicationProps> = ({
-  applicants,
-  boardPositions,
-  onAddClick,
-  onEdit,
-  onDeletePosition,
-  onDeleteApplicant,
-  onMovePosition,
-}) => {
+const BoardTab: React.FC = () => {
+  const { data: boardPositions, loaded: positionsLoaded } = useCollectionData<BoardPosition>(subscribeToPositions, []);
+  const { data: applicants, loaded: applicantsLoaded } = useCollectionData<BoardApplication>(subscribeToBoardApplications, []);
+  const { notify } = useNotify();
   const [expandedDescriptions, setExpandedDescriptions] = useState<Set<string>>(new Set());
   const [expandedCoverLetters, setExpandedCoverLetters] = useState<Set<string>>(new Set());
+  const [showBoardPositionModal, setShowBoardPositionModal] = useState(false);
+  const [editingBoardPosition, setEditingBoardPosition] = useState<BoardPosition | null>(null);
+  const [boardPositionForm, setBoardPositionForm] = useState<BPositionFormState>({ title: "", short: "", description: "" });
 
-  const toggleDescription = (id: string) => {
+  const toggleDescription = (id: string | undefined) => {
+    if (!id) return;
     setExpandedDescriptions((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -47,7 +41,8 @@ const BoardTab: React.FC<ApplicationProps> = ({
     });
   };
 
-  const toggleCoverLetter = (id: string) => {
+  const toggleCoverLetter = (id: string | undefined) => {
+    if (!id) return;
     setExpandedCoverLetters((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -56,29 +51,80 @@ const BoardTab: React.FC<ApplicationProps> = ({
     });
   };
 
+  const handleAddBoardPosition = () => {
+    addPosition({ ...boardPositionForm })
+      .then(() => notify({ type: "success", title: "Position added", message: "The board position was created." }))
+      .catch((e) => {
+        console.error("Failed to add board position:", e);
+        notify({ type: "error", title: "Add failed", message: "Could not add the board position. Please try again." });
+      });
+    setShowBoardPositionModal(false);
+    setBoardPositionForm({ title: "", short: "", description: "" });
+  };
+
+  const handleUpdateBoardPosition = () => {
+    if (!editingBoardPosition) return;
+    updatePosition(editingBoardPosition.id, { ...boardPositionForm })
+      .then(() => notify({ type: "success", title: "Position updated", message: "The board position was saved." }))
+      .catch((e) => {
+        console.error("Failed to update board position:", e);
+        notify({ type: "error", title: "Update failed", message: "Could not update the board position. Please try again." });
+      });
+    setShowBoardPositionModal(false);
+    setEditingBoardPosition(null);
+  };
+
+  const handleDeleteBoardPosition = (id: string) => {
+    if (window.confirm("Delete this Board Position?")) {
+      deletePosition(id).catch((e) => {
+        console.error("Failed to delete board position:", e);
+        notify({ type: "error", title: "Delete failed", message: "Could not delete the board position. Please try again." });
+      });
+    }
+  };
+
+  const handleDeleteBoardApplication = (id: string | undefined) => {
+    if (!id) return;
+    if (window.confirm("Delete this application record?")) {
+      deleteBoardApplication(id).catch((e) => {
+        console.error("Failed to delete application:", e);
+        notify({ type: "error", title: "Delete failed", message: "Could not delete the application. Please try again." });
+      });
+    }
+  };
+
+  const handleMoveBoardPosition = (positionId: string, direction: "up" | "down") => {
+    movePosition(boardPositions, positionId, direction).catch((e) => {
+      console.error("Failed to move position:", e);
+      notify({ type: "error", title: "Reorder failed", message: "Could not reorder board positions. Please try again." });
+    });
+  };
+
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Board Positions</h2>
-        <Button variant="outline" icon={Plus} onClick={onAddClick}>Add new position</Button>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Board Positions</h2>
+        <Button variant="outline" icon={Plus} onClick={() => { setEditingBoardPosition(null); setBoardPositionForm({ title: "", short: "", description: "" }); setShowBoardPositionModal(true); }}>Add new position</Button>
       </div>
       <div className="grid gap-4 mb-6">
-        {boardPositions.length > 0 ? boardPositions.map((position, index) => (
-          <Card key={position.id} className='bg-white dark:bg-gray-800 text-black dark:text-white'>
+        {!positionsLoaded ? (
+          <p className="mono-label text-muted-foreground py-6">Loading…</p>
+        ) : boardPositions.length > 0 ? boardPositions.map((position, index) => (
+          <Card key={position.id}>
             <CardContent className="p-6">
-              <div className="flex justify-between">
+              <div className="flex justify-between gap-4">
                 <div className="flex-1">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{position.title}</h3>
-                  <p className="text-gray-600 dark:text-gray-400">{position.short}</p>
+                  <h3 className="text-lg font-semibold text-foreground">{position.title}</h3>
+                  <p className="text-muted-foreground">{position.short}</p>
                   <button
                     onClick={() => toggleDescription(position.id)}
-                    className="flex items-center gap-1 text-sm text-blue-500 hover:text-blue-600 mt-2 cursor-pointer transition-all duration-200 rounded-sm"
+                    className="flex items-center gap-1 text-sm text-primary hover:brightness-110 mt-2 cursor-pointer transition-all duration-200 rounded-sm"
                   >
                     {expandedDescriptions.has(position.id) ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                    {expandedDescriptions.has(position.id) ? 'Hide description' : 'Show description'}
+                    {expandedDescriptions.has(position.id) ? "Hide description" : "Show description"}
                   </button>
                   {expandedDescriptions.has(position.id) && (
-                    <div className="text-sm text-gray-500 dark:text-gray-400 mt-2 whitespace-pre-wrap">{position.description}</div>
+                    <div className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap">{position.description}</div>
                   )}
                 </div>
                 <div className="flex gap-2 items-start">
@@ -87,7 +133,7 @@ const BoardTab: React.FC<ApplicationProps> = ({
                       size="sm"
                       variant="outline"
                       icon={ArrowUp}
-                      onClick={() => onMovePosition(position.id, 'up')}
+                      onClick={() => handleMoveBoardPosition(position.id, "up")}
                       disabled={index === 0}
                       title="Move up"
                     >
@@ -97,65 +143,70 @@ const BoardTab: React.FC<ApplicationProps> = ({
                       size="sm"
                       variant="outline"
                       icon={ArrowDown}
-                      onClick={() => onMovePosition(position.id, 'down')}
+                      onClick={() => handleMoveBoardPosition(position.id, "down")}
                       disabled={index === boardPositions.length - 1}
                       title="Move down"
                     >
                       <span className="sr-only">Move down</span>
                     </Button>
                   </div>
-                  <Button size="sm" variant="outline" icon={Edit3} onClick={() => onEdit(position)}>Edit</Button>
-                  <Button size="sm" variant="destructive" icon={Trash2} onClick={() => onDeletePosition(position.id)}>
+                  <Button size="sm" variant="outline" icon={Edit3} onClick={() => { setEditingBoardPosition(position); setBoardPositionForm({ title: position.title, short: position.short, description: position.description }); setShowBoardPositionModal(true); }}>Edit</Button>
+                  <Button size="sm" variant="destructive" icon={Trash2} onClick={() => handleDeleteBoardPosition(position.id)}>
                     Delete
                   </Button>
                 </div>
               </div>
             </CardContent>
           </Card>
-        )) : <div className="text-gray-600 dark:text-gray-400 mb-6">No board positions present.</div>}
+        )) : <div className="text-muted-foreground mb-6">No board positions present.</div>}
       </div>
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Received Applications</h2>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Received Applications</h2>
       </div>
       <div className="grid gap-4">
+        {!applicantsLoaded ? (
+          <p className="mono-label text-muted-foreground py-6">Loading…</p>
+        ) : applicants.length === 0 && (
+          <p className="text-sm text-muted-foreground py-8 text-center">No applications received yet.</p>
+        )}
         {applicants.map((applicant) => (
-          <Card key={applicant.id} className='bg-white dark:bg-gray-800 text-black dark:text-white'>
+          <Card key={applicant.id}>
             <CardContent className="p-6">
-              <div className="flex justify-between">
+              <div className="flex justify-between gap-4">
                 <div className="flex-1">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Applying for Role: {applicant.role}</h3>
-                  <p className="text-gray-600 dark:text-gray-400">{applicant.name}</p>
-                  <div className="text-sm text-gray-500 dark:text-gray-400 mt-2">Applied on: {formatApplicationDate(applicant.createdAt)}</div>
-                  <div className="text-sm text-gray-500 dark:text-gray-400 mt-1 whitespace-pre-wrap">{applicant.email}</div>
-                  {applicant.phone && <div className="text-sm text-gray-500 dark:text-gray-400 mt-1">Phone: {applicant.phone}</div>}
-                  <div className="text-sm text-gray-500 dark:text-gray-400 mt-2 whitespace-pre-wrap">{!applicant.coverFile && !applicant.coverText ? "Applicant has not provided a cover letter." : ""}</div>
+                  <h3 className="text-lg font-semibold text-foreground">Applying for Role: {applicant.role}</h3>
+                  <p className="text-muted-foreground">{applicant.name}</p>
+                  <div className="text-sm text-muted-foreground mt-2">Applied on: {formatApplicationDate(applicant.createdAt)}</div>
+                  <div className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap">{applicant.email}</div>
+                  {applicant.phone && <div className="text-sm text-muted-foreground mt-1">Phone: {applicant.phone}</div>}
+                  <div className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap">{!applicant.coverFile && !applicant.coverText ? "Applicant has not provided a cover letter." : ""}</div>
                   {applicant.cv?.url ? (
-                    <div className="text-sm text-blue-500 mt-2">
+                    <div className="text-sm text-primary mt-2">
                       <Link href={applicant.cv.url}>View CV (PDF)</Link>
                     </div>
                   ) : null}
-                  {applicant.coverOption === 'text' && applicant.coverText && (
+                  {applicant.coverOption === "text" && applicant.coverText && applicant.id && (
                     <div className="mt-2">
                       <button
                         onClick={() => toggleCoverLetter(applicant.id)}
-                        className="flex items-center gap-1 text-sm text-blue-500 hover:text-blue-600 cursor-pointer transition-all duration-200 rounded-sm"
+                        className="flex items-center gap-1 text-sm text-primary hover:brightness-110 cursor-pointer transition-all duration-200 rounded-sm"
                       >
                         {expandedCoverLetters.has(applicant.id) ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                        {expandedCoverLetters.has(applicant.id) ? 'Hide cover letter' : 'Show cover letter'}
+                        {expandedCoverLetters.has(applicant.id) ? "Hide cover letter" : "Show cover letter"}
                       </button>
                       {expandedCoverLetters.has(applicant.id) && (
-                        <div className="text-sm text-gray-500 dark:text-gray-400 mt-2 whitespace-pre-wrap border-l-2 border-gray-300 dark:border-gray-600 pl-3 whitespace-pre-wrap">{applicant.coverText}</div>
+                        <div className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap border-l border-border pl-3">{applicant.coverText}</div>
                       )}
                     </div>
                   )}
-                  {applicant.coverOption === 'file' && applicant.coverFile?.url ? (
-                    <div className="text-sm text-blue-500 mt-2">
+                  {applicant.coverOption === "file" && applicant.coverFile?.url ? (
+                    <div className="text-sm text-primary mt-2">
                       <Link href={applicant.coverFile.url}>View Cover Letter (PDF)</Link>
                     </div>
                   ) : null}
                 </div>
                 <div className="flex gap-2">
-                  <Button size="sm" variant="destructive" icon={Trash2} onClick={() => onDeleteApplicant(applicant.id)}>
+                  <Button size="sm" variant="destructive" icon={Trash2} onClick={() => handleDeleteBoardApplication(applicant.id)}>
                     Delete
                   </Button>
                 </div>
@@ -164,6 +215,16 @@ const BoardTab: React.FC<ApplicationProps> = ({
           </Card>
         ))}
       </div>
+
+      <BoardPositionModal
+        open={showBoardPositionModal}
+        onClose={() => { setShowBoardPositionModal(false); setEditingBoardPosition(null); }}
+        form={boardPositionForm}
+        setForm={setBoardPositionForm}
+        editing={!!editingBoardPosition}
+        onAdd={handleAddBoardPosition}
+        onUpdate={handleUpdateBoardPosition}
+      />
     </div>
   );
 };

--- a/components/pages/admin/tabs/BoardTab.tsx
+++ b/components/pages/admin/tabs/BoardTab.tsx
@@ -2,8 +2,15 @@
 
 import React, { useState } from "react";
 import { Button } from "@/components/ui/Button";
+import { Card, CardContent } from "@/components/ui/Card";
 import { BoardPosition } from "@/types";
+import { Edit3, Plus, Trash2, ChevronDown, ChevronUp, ArrowUp, ArrowDown } from "lucide-react";
+import Link from "next/link";
+import BoardPositionModal, { type BPositionFormState } from "@/components/pages/admin/modals/BoardPositionModal";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
+import { subscribeToPositions, addPosition, updatePosition, deletePosition, movePosition } from "@/lib/firestore/board-positions";
 import { subscribeToBoardApplications, deleteBoardApplication, type BoardApplication } from "@/lib/firestore/boardApplications";
+import { useNotify } from "@/components/ui/Notifications";
 
 function formatApplicationDate(createdAt: BoardApplication["createdAt"]): string {
   if (createdAt == null) return "—";
@@ -13,13 +20,16 @@ function formatApplicationDate(createdAt: BoardApplication["createdAt"]): string
   }
   return createdAt.toDate().toDateString();
 }
-import { Card, CardContent } from "@/components/ui/Card";
-import { Edit3, Plus, Trash2, ChevronDown, ChevronUp, ArrowUp, ArrowDown } from "lucide-react";
-import Link from "next/link";
-import BoardPositionModal, { type BPositionFormState } from "@/components/pages/admin/modals/BoardPositionModal";
-import { useCollectionData } from "@/lib/firestore/useCollectionData";
-import { subscribeToPositions, addPosition, updatePosition, deletePosition, movePosition } from "@/lib/firestore/board-positions";
-import { useNotify } from "@/components/ui/Notifications";
+
+/** Only allow http/https URLs to prevent javascript: XSS in href attributes. */
+function safeUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") return url;
+  } catch { /* invalid URL */ }
+  return undefined;
+}
 
 const BoardTab: React.FC = () => {
   const { data: boardPositions, loaded: positionsLoaded } = useCollectionData<BoardPosition>(subscribeToPositions, []);
@@ -182,7 +192,7 @@ const BoardTab: React.FC = () => {
                   <div className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap">{!applicant.coverFile && !applicant.coverText ? "Applicant has not provided a cover letter." : ""}</div>
                   {applicant.cv?.url ? (
                     <div className="text-sm text-primary mt-2">
-                      <Link href={applicant.cv.url}>View CV (PDF)</Link>
+                      <Link href={safeUrl(applicant.cv.url) || "#"}>View CV (PDF)</Link>
                     </div>
                   ) : null}
                   {applicant.coverOption === "text" && applicant.coverText && applicant.id && (
@@ -201,7 +211,7 @@ const BoardTab: React.FC = () => {
                   )}
                   {applicant.coverOption === "file" && applicant.coverFile?.url ? (
                     <div className="text-sm text-primary mt-2">
-                      <Link href={applicant.coverFile.url}>View Cover Letter (PDF)</Link>
+                      <Link href={safeUrl(applicant.coverFile.url) || "#"}>View Cover Letter (PDF)</Link>
                     </div>
                   ) : null}
                 </div>

--- a/components/pages/admin/tabs/EventsTab.tsx
+++ b/components/pages/admin/tabs/EventsTab.tsx
@@ -52,10 +52,6 @@ const EventsTab: React.FC<EventsTabProps> = ({ events }) => {
     externalRegistrationMembersOnly: false,
   });
 
-  useEffect(() => {
-    // keep form defaults when opening modal to add
-  }, []);
-
   const resetForms = () => {
     setEventForm({
       title: '',

--- a/components/pages/admin/tabs/EventsTab.tsx
+++ b/components/pages/admin/tabs/EventsTab.tsx
@@ -26,11 +26,9 @@ const categoryOptions = [
 
 export interface EventsTabProps {
   events: Event[];
-  onManageQuestions: (event: Event) => void;
-  onViewRegistrations: (event: Event) => void;
 }
 
-const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onViewRegistrations }) => {
+const EventsTab: React.FC<EventsTabProps> = ({ events }) => {
   const { dispatch } = useApp();
   const [showEventQModal, setShowEventQModal] = useState(false);
   const [activeEventForQuestions, setActiveEventForQuestions] = useState<Event | null>(null);
@@ -187,25 +185,26 @@ const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onView
   return (
     <div>
       <div className="flex flex-wrap justify-between items-center gap-3 mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Events Management
-        </h2>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Events</h2>
         <Button variant="outline" icon={Plus} onClick={handleAddClick}>
           Add New Event
         </Button>
       </div>
 
       <div className="grid gap-4">
+        {events.length === 0 && (
+          <p className="text-sm text-muted-foreground py-8 text-center">No events yet — add one to get started.</p>
+        )}
         {events.map((event) => ( 
           <Card
             key={event.id}
-            className="bg-white dark:bg-gray-800 text-black dark:text-white overflow-x-auto"
+            className="overflow-x-auto"
           >
             <CardContent className="p-6">
               <div className="flex items-start justify-between flex-col lg:flex-row">
-                <div className="flex-1">
+                <div className="flex-1 min-w-0">
                   <div className="flex items-center space-x-3 mb-2 flex-wrap">
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    <h3 className="text-lg font-semibold text-foreground">
                       {event.title}
                     </h3>
                     <Tag
@@ -220,11 +219,11 @@ const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onView
                       )?.label || event.category}
                     </Tag>
                   </div>
-                  <p className="text-gray-600 mb-2 dark:text-gray-400 whitespace-pre-wrap">
+                  <p className="text-muted-foreground mb-2 whitespace-pre-wrap">
                     {event.description.slice(0, 100) +
                       (event.description.length > 100 ? "..." : "")}
                   </p>
-                  <div className="text-sm text-gray-500 dark:text-gray-400">
+                  <div className="text-sm text-muted-foreground">
                     <span className="mr-4">
                       📅{" "}
                       {event.eventStartAt
@@ -240,7 +239,7 @@ const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onView
                     <span>📍 {event.location}</span>
                   </div>
                   {event.registrationRequired && (
-                    <div className="text-sm text-gray-500 mt-1">
+                    <div className="text-sm text-muted-foreground mt-1">
                       👥 {event.currentRegistrations || 0} / {event.maxCapacity}{" "}
                       registered
                     </div>
@@ -258,14 +257,14 @@ const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onView
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={() => { setActiveEventForQuestions(event); setShowEventQModal(true); onManageQuestions(event); }}
+                    onClick={() => { setActiveEventForQuestions(event); setShowEventQModal(true); }}
                   >
                     Manage Questions
                   </Button>
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={() => { setActiveEventForRegs(event); setShowEventRegsModal(true); onViewRegistrations(event); }}
+                    onClick={() => { setActiveEventForRegs(event); setShowEventRegsModal(true); }}
                   >
                     Registrations
                   </Button>
@@ -302,7 +301,7 @@ const EventsTab: React.FC<EventsTabProps> = ({ events, onManageQuestions, onView
           if (editingItem) handleUpdateEvent(); else handleAddEvent();
         }}
       />
-      {/* Questions modal — moved from AdminDashboard: parent still may call onManageQuestions to toggle */}
+      {/* Questions modal — co-located with the events tab */}
       <EventQuestionsModal
         open={showEventQModal && !!activeEventForQuestions}
         eventTitle={activeEventForQuestions?.title || ''}

--- a/components/pages/admin/tabs/FAQTab.tsx
+++ b/components/pages/admin/tabs/FAQTab.tsx
@@ -1,38 +1,68 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent } from "@/components/ui/Card";
 import { FAQ } from "@/types";
 import { Edit3, Plus, Trash2 } from "lucide-react";
+import FAQModal, { type FAQFormState } from "@/components/pages/admin/modals/FAQModal";
+import { useApp } from "@/contexts/AppContext";
 
-export interface FAQTabProps {
-  faqs: FAQ[];
-  onAddClick: () => void;
-  onEdit: (faq: FAQ) => void;
-  onDelete: (id: string) => void;
-}
+const FAQTab: React.FC = () => {
+  const { state, dispatch } = useApp();
+  const faqs = state.faqs;
+  const [showFaqModal, setShowFaqModal] = useState(false);
+  const [editingFaq, setEditingFaq] = useState<FAQ | null>(null);
+  const [faqForm, setFaqForm] = useState<FAQFormState>({
+    question: "",
+    answer: "",
+    category: "General",
+    order: state.faqs.length + 1,
+    published: true,
+  });
 
-const FAQTab: React.FC<FAQTabProps> = ({ faqs, onAddClick, onEdit, onDelete }) => {
+  const handleAddFaq = () => {
+    const payload = { ...faqForm };
+    dispatch({ firestoreAction: "ADD_FAQS", payload });
+    setShowFaqModal(false);
+    setFaqForm({ question: "", answer: "", category: "General", order: state.faqs.length + 1, published: true });
+  };
+
+  const handleUpdateFaq = () => {
+    if (!editingFaq) return;
+    dispatch({ firestoreAction: "UPDATE_FAQS", payload: { ...editingFaq, ...faqForm } as FAQ });
+    setShowFaqModal(false);
+    setEditingFaq(null);
+  };
+
+  const handleDeleteFaq = (id: string) => {
+    if (window.confirm("Delete this FAQ?")) {
+      dispatch({ firestoreAction: "DELETE_FAQS", payload: id });
+    }
+  };
+
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">FAQ Management</h2>
-        <Button variant="outline" icon={Plus} onClick={onAddClick}>Add FAQ</Button>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">FAQ</h2>
+        <Button variant="outline" icon={Plus} onClick={() => { setEditingFaq(null); setFaqForm({ question: "", answer: "", category: "General", order: state.faqs.length + 1, published: true }); setShowFaqModal(true); }}>Add FAQ</Button>
       </div>
       <div className="grid gap-4">
+        {faqs.length === 0 && (
+          <p className="text-sm text-muted-foreground py-8 text-center">No FAQs yet — add one to get started.</p>
+        )}
         {faqs.map((faq) => (
-          <Card key={faq.id} className='bg-white dark:bg-gray-800 text-black dark:text-white'>
+          <Card key={faq.id}>
             <CardContent className="p-6">
-              <div className="flex justify-between">
+              <div className="flex justify-between gap-4">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{faq.question}</h3>
-                  <p className="text-gray-600 dark:text-gray-400">{faq.answer}</p>
-                  <div className="text-sm text-gray-500 mt-2">{faq.category} • Order {faq.order} • {faq.published ? 'Published' : 'Hidden'}</div>
+                  <h3 className="text-lg font-semibold text-foreground">{faq.question}</h3>
+                  <p className="text-muted-foreground">{faq.answer}</p>
+                  <div className="font-mono text-[0.6875rem] uppercase tracking-[0.12em] text-muted-foreground/70 mt-2">{faq.category} · Order {faq.order} · {faq.published ? "Published" : "Hidden"}</div>
                 </div>
-                <div className="flex gap-2">
-                  <Button size="sm" variant="outline" icon={Edit3} onClick={() => onEdit(faq)}>Edit</Button>
-                  <Button size="sm" variant="destructive" icon={Trash2} onClick={() => onDelete(faq.id)}>
+                <div className="flex gap-2 shrink-0">
+                  <Button size="sm" variant="outline" icon={Edit3} onClick={() => { setEditingFaq(faq); setFaqForm({ question: faq.question, answer: faq.answer, category: faq.category, order: faq.order, published: faq.published }); setShowFaqModal(true); }}>Edit</Button>
+                  <Button size="sm" variant="destructive" icon={Trash2} onClick={() => handleDeleteFaq(faq.id)}>
                     Delete
                   </Button>
                 </div>
@@ -41,6 +71,16 @@ const FAQTab: React.FC<FAQTabProps> = ({ faqs, onAddClick, onEdit, onDelete }) =
           </Card>
         ))}
       </div>
+
+      <FAQModal
+        open={showFaqModal}
+        onClose={() => { setShowFaqModal(false); setEditingFaq(null); }}
+        form={faqForm}
+        setForm={setFaqForm}
+        editing={!!editingFaq}
+        onAdd={handleAddFaq}
+        onUpdate={handleUpdateFaq}
+      />
     </div>
   );
 };

--- a/components/pages/admin/tabs/JobsTab.tsx
+++ b/components/pages/admin/tabs/JobsTab.tsx
@@ -109,7 +109,7 @@ const JobsTab: React.FC = () => {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Jobs Management</h2>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Jobs</h2>
         <Button variant="outline" icon={Plus} onClick={handleOpenNew}>New Job</Button>
       </div>
 
@@ -120,7 +120,7 @@ const JobsTab: React.FC = () => {
               <div className="flex items-start justify-between">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2 flex-wrap">
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{job.title}</h3>
+                    <h3 className="text-lg font-semibold text-foreground">{job.title}</h3>
                     <Tag variant="red" size="sm">{job.company}</Tag>
                     <Tag variant="yellow" size="sm">{job.type.replace('_', ' ')}</Tag>
                     {job.location && <Tag variant="green" size="sm">{job.location}</Tag>}
@@ -128,7 +128,7 @@ const JobsTab: React.FC = () => {
                       {job.published ? 'Published' : 'Draft'}
                     </Tag>
                   </div>
-                  <p className="text-gray-600 dark:text-gray-400 mb-2 line-clamp-3">{job.description}</p>
+                  <p className="text-muted-foreground mb-2 line-clamp-3">{job.description}</p>
                   {Array.isArray(job.tags) && job.tags.length > 0 && (
                     <div className="flex flex-wrap gap-2">
                       {job.tags.map((t, i) => (
@@ -153,7 +153,7 @@ const JobsTab: React.FC = () => {
           </Card>
         ))}
         {jobs.length === 0 && (
-          <div className="text-gray-600 dark:text-gray-300">No jobs yet. Click &quot;New Job&quot; to add one.</div>
+          <div className="text-muted-foreground py-8 text-center">No jobs yet. Click &quot;New Job&quot; to add one.</div>
         )}
       </div>
 

--- a/components/pages/admin/tabs/TeamTab.tsx
+++ b/components/pages/admin/tabs/TeamTab.tsx
@@ -147,7 +147,7 @@ const updatedMember = {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Team Management</h2>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Team</h2>
         <Button variant="outline" icon={Plus} onClick={handleAddClick}>Add Team Member</Button>
       </div>
 
@@ -157,8 +157,8 @@ const updatedMember = {
             onClick={() => setActiveYear(null)}
             className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
               activeYear === null
-                ? 'bg-red-600 text-white'
-                : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-foreground/[0.06] text-muted-foreground hover:bg-foreground/[0.1] hover:text-foreground'
             }`}
           >
             All ({sortedMembers.length})
@@ -169,8 +169,8 @@ const updatedMember = {
               onClick={() => setActiveYear(year)}
               className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
                 activeYear === year
-                  ? 'bg-red-600 text-white'
-                  : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-foreground/[0.06] text-muted-foreground hover:bg-foreground/[0.1] hover:text-foreground'
               }`}
             >
               {year} ({sortedMembers.filter(m => m.years?.includes(year)).length})
@@ -180,8 +180,11 @@ const updatedMember = {
       )}
 
       <div className="grid md:grid-cols-2 gap-6">
+        {filteredMembers.length === 0 && (
+          <p className="text-sm text-muted-foreground py-8 text-center md:col-span-2">No team members here yet — add one to get started.</p>
+        )}
         {filteredMembers.map((member, index) => (
-          <Card key={member.id} className="bg-gray-50 dark:bg-gray-800 text-black dark:text-white">
+          <Card key={member.id}>
             <CardContent className="p-6">
               <div className="flex items-start space-x-4">
                 <Image
@@ -193,22 +196,22 @@ const updatedMember = {
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{member.name}</h3>
+                    <h3 className="text-lg font-semibold text-foreground">{member.name}</h3>
                     {member.badge && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
                         {member.badge}
                       </span>
                     )}
                   </div>
-                  <p className="text-red-600 font-medium mb-1">{member.position}</p>
+                  <p className="text-primary font-medium mb-1">{member.position}</p>
                   {member.teams && member.teams.length > 0 && (
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                    <p className="text-xs text-muted-foreground mb-1">
                       Teams: {member.teams.map(t => TEAM_CATEGORY_LABELS[t as keyof typeof TEAM_CATEGORY_LABELS] || t).join(', ')}
                       {member.years && member.years.length > 0 && ` · ${member.years.join(', ')}`}
                     </p>
                   )}
                   {member.bio && (
-                    <p className="text-gray-600 text-sm line-clamp-2 dark:text-gray-400">{member.bio}</p>
+                    <p className="text-muted-foreground text-sm line-clamp-2">{member.bio}</p>
                   )}
                   {member.notes && (
                     <p className="text-xs text-muted-foreground italic mt-1 truncate">Note: {member.notes}</p>

--- a/components/pages/admin/tabs/analytics/AnalyticsAITab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsAITab.tsx
@@ -24,7 +24,7 @@ const AITab: React.FC<Props> = ({ aiAnalytics }) => (
     {aiAnalytics && (
       <div className="grid md:grid-cols-2 gap-6">
         <Card>
-          <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Chats Per Day</h4></CardHeader>
+          <CardHeader><h4 className="font-semibold text-foreground">Chats Per Day</h4></CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={200}>
               <LineChart data={aiAnalytics.chatsPerDay} margin={{ left: 10, right: 10 }}>
@@ -39,7 +39,7 @@ const AITab: React.FC<Props> = ({ aiAnalytics }) => (
         </Card>
 
         <Card>
-          <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Messages Per Day</h4></CardHeader>
+          <CardHeader><h4 className="font-semibold text-foreground">Messages Per Day</h4></CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={200}>
               <LineChart data={aiAnalytics.messagesPerDay} margin={{ left: 10, right: 10 }}>
@@ -54,7 +54,7 @@ const AITab: React.FC<Props> = ({ aiAnalytics }) => (
         </Card>
 
         <Card className="md:col-span-2">
-          <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Top Recommended Courses</h4></CardHeader>
+          <CardHeader><h4 className="font-semibold text-foreground">Top Recommended Courses</h4></CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>
               <BarChart data={aiAnalytics.topRecommendedCourses} layout="vertical" margin={{ left: 20, right: 20 }}>
@@ -71,7 +71,7 @@ const AITab: React.FC<Props> = ({ aiAnalytics }) => (
     )}
 
     {!aiAnalytics && (
-      <p className="text-gray-500 dark:text-gray-400 text-sm italic">
+      <p className="text-muted-foreground text-sm italic">
         No AI chat data available yet.
       </p>
     )}

--- a/components/pages/admin/tabs/analytics/AnalyticsEventsTab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsEventsTab.tsx
@@ -29,12 +29,12 @@ const statusLabel: Record<string, string> = {
 };
 
 const statusColor: Record<string, string> = {
-  registered: "text-blue-600",
+  registered: "text-primary",
   waitlist: "text-amber-600",
   invited: "text-purple-600",
   confirmed: "text-green-600",
   declined: "text-red-600",
-  cancelled: "text-gray-500",
+  cancelled: "text-muted-foreground",
 };
 
 const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
@@ -87,22 +87,22 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
           onClick={closeDetail}
           variant="outline"
           size="sm"
-          className="cursor-pointer inline-flex items-center gap-1.5 text-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white transition-all duration-200"
+          className="cursor-pointer inline-flex items-center gap-1.5 text-sm bg-foreground/[0.08] hover:bg-foreground/[0.12] text-muted-foreground hover:text-foreground transition-all duration-200"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to all events
         </Button>
 
-        <h3 className="text-xl font-bold text-gray-900 dark:text-white">{selectedEvent.title}</h3>
+        <h3 className="text-xl font-bold text-foreground">{selectedEvent.title}</h3>
 
         {detailLoading && (
           <div className="animate-pulse space-y-6">
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
               {Array.from({ length: 6 }).map((_, i) => (
-                <div key={i} className="bg-gray-200 dark:bg-gray-700 rounded-lg h-20" />
+                <div key={i} className="bg-foreground/[0.06] rounded-lg h-20" />
               ))}
             </div>
-            <div className="bg-gray-200 dark:bg-gray-700 rounded-lg h-64" />
+            <div className="bg-foreground/[0.06] rounded-lg h-64" />
           </div>
         )}
 
@@ -113,10 +113,10 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
               {Object.entries(detailData.statusCounts).map(([status, count]) => (
                 <Card key={status}>
                   <CardContent className="p-4 text-center">
-                    <p className={`text-lg font-bold ${statusColor[status] || "text-gray-900 dark:text-white"}`}>
+                    <p className={`text-lg font-bold ${statusColor[status] || "text-foreground"}`}>
                       {count}
                     </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    <p className="text-xs text-muted-foreground mt-0.5">
                       {statusLabel[status] || status}
                     </p>
                   </CardContent>
@@ -127,7 +127,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
             {/* Registrations per day */}
             {detailData.registrationsPerDay.length > 0 && (
               <Card>
-                <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Registrations Per Day</h4></CardHeader>
+                <CardHeader><h4 className="font-semibold text-foreground">Registrations Per Day</h4></CardHeader>
                 <CardContent>
                   <ResponsiveContainer width="100%" height={200}>
                     <LineChart data={detailData.registrationsPerDay} margin={{ left: 10, right: 10 }}>
@@ -148,7 +148,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
               <div className="grid md:grid-cols-2 gap-6">
                 {Object.keys(detailData.memberDemographics.gender).length > 0 && (
                   <Card>
-                    <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Gender</h4></CardHeader>
+                    <CardHeader><h4 className="font-semibold text-foreground">Gender</h4></CardHeader>
                     <CardContent>
                       <div className="space-y-1.5">
                         {Object.entries(detailData.memberDemographics.gender)
@@ -158,12 +158,12 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                             const pct = total > 0 ? Math.round((count / total) * 100) : 0;
                             return (
                               <div key={label} className="flex items-center gap-3 text-sm">
-                                <span className="flex-1 text-gray-700 dark:text-gray-300 capitalize">{label}</span>
-                                <span className="font-semibold text-gray-900 dark:text-white w-8 text-right">{count}</span>
-                                <div className="w-20 h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden shrink-0">
+                                <span className="flex-1 text-foreground/80 capitalize">{label}</span>
+                                <span className="font-semibold text-foreground w-8 text-right">{count}</span>
+                                <div className="w-20 h-2 bg-foreground/[0.06] rounded-full overflow-hidden shrink-0">
                                   <div className="h-full bg-blue-500 rounded-full transition-all" style={{ width: `${pct}%` }} />
                                 </div>
-                                <span className="text-xs text-gray-400 w-10 text-right">{pct}%</span>
+                                <span className="text-xs text-muted-foreground w-10 text-right">{pct}%</span>
                               </div>
                             );
                           })}
@@ -173,7 +173,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                 )}
                 {Object.keys(detailData.memberDemographics.studentStatus).length > 0 && (
                   <Card>
-                    <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Student Status</h4></CardHeader>
+                    <CardHeader><h4 className="font-semibold text-foreground">Student Status</h4></CardHeader>
                     <CardContent>
                       <div className="space-y-1.5">
                         {Object.entries(detailData.memberDemographics.studentStatus)
@@ -183,12 +183,12 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                             const pct = total > 0 ? Math.round((count / total) * 100) : 0;
                             return (
                               <div key={label} className="flex items-center gap-3 text-sm">
-                                <span className="flex-1 text-gray-700 dark:text-gray-300 capitalize">{label}</span>
-                                <span className="font-semibold text-gray-900 dark:text-white w-8 text-right">{count}</span>
-                                <div className="w-20 h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden shrink-0">
+                                <span className="flex-1 text-foreground/80 capitalize">{label}</span>
+                                <span className="font-semibold text-foreground w-8 text-right">{count}</span>
+                                <div className="w-20 h-2 bg-foreground/[0.06] rounded-full overflow-hidden shrink-0">
                                   <div className="h-full bg-green-500 rounded-full transition-all" style={{ width: `${pct}%` }} />
                                 </div>
-                                <span className="text-xs text-gray-400 w-10 text-right">{pct}%</span>
+                                <span className="text-xs text-muted-foreground w-10 text-right">{pct}%</span>
                               </div>
                             );
                           })}
@@ -208,14 +208,14 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                   return (
                     <Card key={q.questionId}>
                       <CardHeader>
-                        <h4 className="font-semibold text-gray-900 dark:text-white text-sm">
+                        <h4 className="font-semibold text-foreground text-sm">
                           {q.questionText}
                         </h4>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 capitalize">{q.type} · {detailData.total} responses</p>
+                        <p className="text-xs text-muted-foreground capitalize">{q.type} · {detailData.total} responses</p>
                       </CardHeader>
                       <CardContent>
                         {entries.length === 0 && (
-                          <p className="text-sm text-gray-400 italic">No answers</p>
+                          <p className="text-sm text-muted-foreground italic">No answers</p>
                         )}
                         {entries.length > 0 && (
                           <div className="space-y-1.5">
@@ -223,15 +223,15 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                               const pct = total > 0 ? Math.round((count / total) * 100) : 0;
                               return (
                                 <div key={answer} className="flex items-center gap-3 text-sm">
-                                  <span className="flex-1 text-gray-700 dark:text-gray-300 truncate">{answer}</span>
-                                  <span className="font-semibold text-gray-900 dark:text-white w-8 text-right">{count}</span>
-                                  <div className="w-20 h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden shrink-0">
+                                  <span className="flex-1 text-foreground/80 truncate">{answer}</span>
+                                  <span className="font-semibold text-foreground w-8 text-right">{count}</span>
+                                  <div className="w-20 h-2 bg-foreground/[0.06] rounded-full overflow-hidden shrink-0">
                                     <div
                                       className="h-full bg-red-500 rounded-full transition-all"
                                       style={{ width: `${pct}%` }}
                                     />
                                   </div>
-                                  <span className="text-xs text-gray-400 w-10 text-right">{pct}%</span>
+                                  <span className="text-xs text-muted-foreground w-10 text-right">{pct}%</span>
                                 </div>
                               );
                             })}
@@ -245,7 +245,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
             )}
 
             {detailData.questions.length === 0 && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+              <p className="text-sm text-muted-foreground italic">
                 No select/radio/checkbox questions for this event.
               </p>
             )}
@@ -253,7 +253,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
         )}
 
         {!detailLoading && !detailData && (
-          <p className="text-sm text-gray-500 dark:text-gray-400 italic">Failed to load event details.</p>
+          <p className="text-sm text-muted-foreground italic">Failed to load event details.</p>
         )}
       </div>
     );
@@ -265,7 +265,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            <h3 className="text-lg font-semibold text-foreground">
               Event Funnel — Click → Registration → Attendance
             </h3>
             <Button size="sm" variant="outline" icon={Download} onClick={downloadFunnelCsv}>
@@ -277,7 +277,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
               <thead>
-                <tr className="text-left text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                <tr className="text-left text-muted-foreground border-b border-border">
                   <th className="py-2 pr-4 whitespace-nowrap">Event</th>
                   <th className="py-2 pr-4 whitespace-nowrap">Date</th>
                   <th className="py-2 pr-4 whitespace-nowrap">Clicks</th>
@@ -293,12 +293,12 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                   <tr
                     key={f.eventId}
                     onClick={() => openEvent(f.eventId)}
-                    className="border-b border-gray-100 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+                    className="border-b border-border cursor-pointer hover:bg-foreground/[0.04] transition-colors"
                   >
-                    <td className="py-2 pr-4 font-medium text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap">
+                    <td className="py-2 pr-4 font-medium text-primary hover:brightness-110 hover:underline whitespace-nowrap">
                       {f.title}
                     </td>
-                    <td className="py-2 pr-4 text-gray-700 dark:text-gray-300 whitespace-nowrap">{shortDate(f.date)}</td>
+                    <td className="py-2 pr-4 text-foreground/80 whitespace-nowrap">{shortDate(f.date)}</td>
                     <td className="py-2 pr-4 whitespace-nowrap">{f.clicks}</td>
                     <td className="py-2 pr-4 whitespace-nowrap">{f.registrations}</td>
                     <td className="py-2 pr-4 whitespace-nowrap">{f.attended}</td>
@@ -317,13 +317,13 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                         const evt = events.find((e) => e.id === f.eventId);
                         return evt?.feedbackFormUrl ? (
                           <a href={evt.feedbackFormUrl} target="_blank" rel="noreferrer"
-                            className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+                            className="inline-flex items-center gap-1 text-primary hover:brightness-110 hover:underline"
                             onClick={(e) => e.stopPropagation()}
                           >
                             Form <ExternalLink className="h-3 w-3" />
                           </a>
                         ) : (
-                          <span className="text-gray-400">—</span>
+                          <span className="text-muted-foreground">—</span>
                         );
                       })()}
                     </td>
@@ -331,7 +331,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                 ))}
                 {funnelData.length === 0 && (
                   <tr>
-                    <td colSpan={8} className="py-4 text-gray-500 dark:text-gray-400 text-center">No events found</td>
+                    <td colSpan={8} className="py-4 text-muted-foreground text-center">No events found</td>
                   </tr>
                 )}
               </tbody>
@@ -343,12 +343,12 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
       {regAnalytics && (
         <div className="grid md:grid-cols-2 gap-6">
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Registration Status Across Events</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Registration Status Across Events</h4></CardHeader>
             <CardContent>
               <div className="overflow-x-auto">
                 <table className="min-w-full text-sm">
                   <thead>
-                    <tr className="text-left text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                    <tr className="text-left text-muted-foreground border-b border-border">
                       <th className="py-2 pr-4 whitespace-nowrap">Event</th>
                       <th className="py-2 pr-4 whitespace-nowrap">Reg.</th>
                       <th className="py-2 pr-4 whitespace-nowrap">Wait.</th>
@@ -362,8 +362,8 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
                     {Object.entries(regAnalytics.statusBreakdownPerEvent).map(([eid, s]) => {
                       const evt = events.find((e) => e.id === eid);
                       return (
-                        <tr key={eid} className="border-b border-gray-100 dark:border-gray-700/50">
-                          <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white whitespace-nowrap">{evt?.title || eid.slice(0, 8)}</td>
+                        <tr key={eid} className="border-b border-border">
+                          <td className="py-2 pr-4 font-medium text-foreground whitespace-nowrap">{evt?.title || eid.slice(0, 8)}</td>
                           <td className="py-2 pr-4 whitespace-nowrap">{s.registered}</td>
                           <td className="py-2 pr-4 whitespace-nowrap">{s.waitlist}</td>
                           <td className="py-2 pr-4 whitespace-nowrap">{s.invited}</td>
@@ -380,7 +380,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
           </Card>
 
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Registrations Per Day</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Registrations Per Day</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={regAnalytics.registrationsPerDay} margin={{ left: 10, right: 10 }}>
@@ -396,7 +396,7 @@ const EventsTab: React.FC<Props> = ({ funnelData, events, regAnalytics }) => {
         </div>
       )}
 
-      <p className="text-xs text-gray-500 dark:text-gray-400">
+      <p className="text-xs text-muted-foreground">
         Clicks are deduped client-side per browser (cookie-consent gated). Click an event to see detailed registration answers.
       </p>
     </div>

--- a/components/pages/admin/tabs/analytics/AnalyticsFirebaseTab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsFirebaseTab.tsx
@@ -17,7 +17,7 @@ interface Props {
 const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
   <div className="space-y-4">
     {firebaseLoading && (
-      <p className="text-gray-500 dark:text-gray-400">Loading Firebase Analytics…</p>
+      <p className="text-muted-foreground">Loading Firebase Analytics…</p>
     )}
 
     {!firebaseLoading && firebaseData && !firebaseData.configured && (
@@ -27,17 +27,17 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
             <Flame className="h-6 w-6" />
             <h3 className="text-lg font-semibold">Firebase Analytics — Not Configured</h3>
           </div>
-          <p className="text-gray-600 dark:text-gray-400 text-sm">{firebaseData.message}</p>
-          <div className="text-sm text-gray-500 dark:text-gray-400 space-y-1 border-t border-gray-200 dark:border-gray-700 pt-3">
-            <p className="font-medium text-gray-700 dark:text-gray-300">Setup steps:</p>
+          <p className="text-muted-foreground text-sm">{firebaseData.message}</p>
+          <div className="text-sm text-muted-foreground space-y-1 border-t border-border pt-3">
+            <p className="font-medium text-foreground/80">Setup steps:</p>
             <ol className="list-decimal list-inside space-y-1">
               <li>Find your GA4 property ID: Google Analytics → <strong>Admin → Property Settings</strong> (numeric ID)</li>
-              <li>Add <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">GA4_PROPERTY_ID</code> to your <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">.env.local</code></li>
-              <li>Enable the <strong>Google Analytics Data API</strong> at <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">console.cloud.google.com/apis/library/analyticsdata.googleapis.com</code></li>
+              <li>Add <code className="bg-foreground/[0.06] px-1 rounded">GA4_PROPERTY_ID</code> to your <code className="bg-foreground/[0.06] px-1 rounded">.env.local</code></li>
+              <li>Enable the <strong>Google Analytics Data API</strong> at <code className="bg-foreground/[0.06] px-1 rounded">console.cloud.google.com/apis/library/analyticsdata.googleapis.com</code></li>
               <li>In GA4 Admin → <strong>Property Access Management</strong>, add your Firebase service account email as a <strong>Viewer</strong></li>
             </ol>
             <p className="mt-2 text-xs">
-              Your Firebase service account email is the value of <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">client_email</code> in your service account JSON file.
+              Your Firebase service account email is the value of <code className="bg-foreground/[0.06] px-1 rounded">client_email</code> in your service account JSON file.
             </p>
           </div>
         </CardContent>
@@ -55,7 +55,7 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
 
         <div className="grid md:grid-cols-2 gap-6">
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Daily Active Users & Page Views</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Daily Active Users & Page Views</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={firebaseData.rows} margin={{ left: 10, right: 10 }}>
@@ -72,7 +72,7 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
           </Card>
 
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Sessions & Events</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Sessions & Events</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={firebaseData.rows} margin={{ left: 10, right: 10 }}>
@@ -89,7 +89,7 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
           </Card>
 
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">New vs Returning Users</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">New vs Returning Users</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={firebaseData.rows} margin={{ left: 10, right: 10 }}>
@@ -106,7 +106,7 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
           </Card>
 
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Avg Session Duration & Bounce Rate</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Avg Session Duration & Bounce Rate</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={firebaseData.rows} margin={{ left: 10, right: 10 }}>
@@ -125,12 +125,12 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
         </div>
 
         <Card>
-          <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Daily Breakdown</h4></CardHeader>
+          <CardHeader><h4 className="font-semibold text-foreground">Daily Breakdown</h4></CardHeader>
           <CardContent>
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm">
                 <thead>
-                  <tr className="text-left text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                  <tr className="text-left text-muted-foreground border-b border-border">
                     <th className="py-2 pr-4">Date</th>
                     <th className="py-2 pr-4">Active Users</th>
                     <th className="py-2 pr-4">Page Views</th>
@@ -143,8 +143,8 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
                 </thead>
                 <tbody>
                   {firebaseData.rows.map((row) => (
-                    <tr key={row.date} className="border-b border-gray-100 dark:border-gray-700/50">
-                      <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">{row.date}</td>
+                    <tr key={row.date} className="border-b border-border">
+                      <td className="py-2 pr-4 font-medium text-foreground">{row.date}</td>
                       <td className="py-2 pr-4">{row.activeUsers}</td>
                       <td className="py-2 pr-4">{row.screenPageViews}</td>
                       <td className="py-2 pr-4">{row.sessions}</td>
@@ -163,7 +163,7 @@ const FirebaseTab: React.FC<Props> = ({ firebaseData, firebaseLoading }) => (
     )}
 
     {!firebaseLoading && !firebaseData && (
-      <p className="text-gray-500 dark:text-gray-400 text-sm italic">No data available.</p>
+      <p className="text-muted-foreground text-sm italic">No data available.</p>
     )}
   </div>
 );

--- a/components/pages/admin/tabs/analytics/AnalyticsJobsTab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsJobsTab.tsx
@@ -25,7 +25,7 @@ const JobsTab: React.FC<Props> = ({ jobs, jobClicks }) => {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h3 className="text-lg font-semibold text-foreground">
             Jobs — {jobs.length} posting{jobs.length !== 1 ? "s" : ""}
           </h3>
           <Button size="sm" variant="outline" icon={Download} onClick={downloadJobsCsv}>CSV</Button>
@@ -35,7 +35,7 @@ const JobsTab: React.FC<Props> = ({ jobs, jobClicks }) => {
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
             <thead>
-              <tr className="text-left text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+              <tr className="text-left text-muted-foreground border-b border-border">
                 <th className="py-2 pr-4">Job</th>
                 <th className="py-2 pr-4">Company</th>
                 <th className="py-2 pr-4">Type</th>
@@ -44,20 +44,20 @@ const JobsTab: React.FC<Props> = ({ jobs, jobClicks }) => {
             </thead>
             <tbody>
               {jobs.map((j) => (
-                <tr key={j.id} className="border-b border-gray-100 dark:border-gray-700/50">
-                  <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">{j.title}</td>
-                  <td className="py-2 pr-4 text-gray-700 dark:text-gray-300">{j.company}</td>
-                  <td className="py-2 pr-4 text-gray-500">{j.type.replace("_", " ")}</td>
+                <tr key={j.id} className="border-b border-border">
+                  <td className="py-2 pr-4 font-medium text-foreground">{j.title}</td>
+                  <td className="py-2 pr-4 text-foreground/80">{j.company}</td>
+                  <td className="py-2 pr-4 text-muted-foreground">{j.type.replace("_", " ")}</td>
                   <td className="py-2 pr-4">{jobClicks[j.id] ?? 0}</td>
                 </tr>
               ))}
               {jobs.length === 0 && (
-                <tr><td colSpan={4} className="py-4 text-gray-500 dark:text-gray-400 text-center">No job postings found</td></tr>
+                <tr><td colSpan={4} className="py-4 text-muted-foreground text-center">No job postings found</td></tr>
               )}
             </tbody>
           </table>
         </div>
-        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-3 text-xs text-muted-foreground">
           Apply clicks are tracked with client-side deduplication (cookie-consent gated).
         </p>
       </CardContent>

--- a/components/pages/admin/tabs/analytics/AnalyticsMembersTab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsMembersTab.tsx
@@ -58,7 +58,7 @@ const MembersTab: React.FC<Props> = ({ memberAnalytics, chartData, eventMarkers 
       {memberAnalytics && (
         <div className="grid md:grid-cols-2 gap-6">
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">How users heard of us</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">How users heard of us</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <BarChart data={topN(memberAnalytics.heardOfUs, 6)} layout="vertical" margin={{ left: 20, right: 20 }}>
@@ -72,7 +72,7 @@ const MembersTab: React.FC<Props> = ({ memberAnalytics, chartData, eventMarkers 
             </CardContent>
           </Card>
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Gender balance</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Gender balance</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <BarChart data={topN(memberAnalytics.gender, 8)} margin={{ left: 20, right: 20 }}>
@@ -86,7 +86,7 @@ const MembersTab: React.FC<Props> = ({ memberAnalytics, chartData, eventMarkers 
             </CardContent>
           </Card>
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Student status</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Student status</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={200}>
                 <BarChart data={topN(memberAnalytics.studentStatus, 8)} margin={{ left: 20, right: 20 }}>
@@ -100,7 +100,7 @@ const MembersTab: React.FC<Props> = ({ memberAnalytics, chartData, eventMarkers 
             </CardContent>
           </Card>
           <Card>
-            <CardHeader><h4 className="font-semibold text-gray-900 dark:text-white">Users over time</h4></CardHeader>
+            <CardHeader><h4 className="font-semibold text-foreground">Users over time</h4></CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={250}>
                 <LineChart data={chartData} margin={{ left: 10, right: 10 }}>
@@ -117,7 +117,7 @@ const MembersTab: React.FC<Props> = ({ memberAnalytics, chartData, eventMarkers 
                 </LineChart>
               </ResponsiveContainer>
               {eventMarkers.length > 0 && (
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Orange dashed lines mark months with events.</p>
+                <p className="text-xs text-muted-foreground mt-1">Orange dashed lines mark months with events.</p>
               )}
             </CardContent>
           </Card>

--- a/components/pages/admin/tabs/analytics/AnalyticsNewsletterTab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsNewsletterTab.tsx
@@ -39,7 +39,7 @@ const NewsletterTab: React.FC<Props> = ({ blogs, blogReads }) => {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Blog Engagement</h3>
+          <h3 className="text-lg font-semibold text-foreground">Blog Engagement</h3>
           <Button size="sm" variant="outline" icon={Download} onClick={downloadNewsletterCsv}>CSV</Button>
         </div>
       </CardHeader>
@@ -47,7 +47,7 @@ const NewsletterTab: React.FC<Props> = ({ blogs, blogReads }) => {
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
             <thead>
-              <tr className="text-left text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+              <tr className="text-left text-muted-foreground border-b border-border">
                 <th className="py-2 pr-4">Title</th>
                 <th className="py-2 pr-4">Date</th>
                 <th className="py-2 pr-4">Reads</th>
@@ -58,9 +58,9 @@ const NewsletterTab: React.FC<Props> = ({ blogs, blogReads }) => {
             </thead>
             <tbody>
               {blogs.map((b) => (
-                <tr key={b.id} className="border-b border-gray-100 dark:border-gray-700/50">
-                  <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">{b.title}</td>
-                  <td className="py-2 pr-4 text-gray-700 dark:text-gray-300">{b.date}</td>
+                <tr key={b.id} className="border-b border-border">
+                  <td className="py-2 pr-4 font-medium text-foreground">{b.title}</td>
+                  <td className="py-2 pr-4 text-foreground/80">{b.date}</td>
                   <td className="py-2 pr-4">{blogReads[b.id] ?? 0}</td>
                   <td className="py-2 pr-4">{reactions[b.id]?.likes ?? 0}</td>
                   <td className="py-2 pr-4">{reactions[b.id]?.dislikes ?? 0}</td>
@@ -68,12 +68,12 @@ const NewsletterTab: React.FC<Props> = ({ blogs, blogReads }) => {
                 </tr>
               ))}
               {blogs.length === 0 && (
-                <tr><td colSpan={6} className="py-4 text-gray-500 dark:text-gray-400 text-center">No posts found</td></tr>
+                <tr><td colSpan={6} className="py-4 text-muted-foreground text-center">No posts found</td></tr>
               )}
             </tbody>
           </table>
         </div>
-        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-3 text-xs text-muted-foreground">
           Reads are deduped per device. Likes, dislikes and shares feed the AI News Desk&apos;s generation feedback.
         </p>
       </CardContent>

--- a/components/pages/admin/tabs/analytics/AnalyticsOverviewTab.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsOverviewTab.tsx
@@ -3,7 +3,8 @@
 import React from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Row } from "./AnalyticsShared";
-import type { Event, BlogPost, Job, TeamMember, BoardPosition, Application } from "@/types";
+import type { Event, BlogPost, Job, TeamMember, BoardPosition } from "@/types";
+import type { BoardApplication } from "@/lib/firestore/boardApplications";
 import type { MemberAnalytics } from "@/lib/firestore/member-analytics";
 import type { EventFunnel } from "@/lib/firestore/event-funnel";
 import type { AIAnalytics } from "@/lib/firestore/ai-analytics";
@@ -14,7 +15,7 @@ interface Props {
   jobs: Job[];
   teamMembers: TeamMember[];
   boardPositions: BoardPosition[];
-  applicants: Application[];
+  applicants: BoardApplication[];
   eventClicks: Record<string, number>;
   blogReads: Record<string, number>;
   jobClicks: Record<string, number>;
@@ -33,7 +34,7 @@ const OverviewTab: React.FC<Props> = ({
 }) => (
   <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
     <Card>
-      <CardHeader><h3 className="text-lg font-semibold text-gray-900 dark:text-white">Events</h3></CardHeader>
+      <CardHeader><h3 className="text-lg font-semibold text-foreground">Events</h3></CardHeader>
       <CardContent className="space-y-3">
         <Row label="Total events" value={events.length} />
         <Row label="Unique clicks" value={totalClicks} />
@@ -42,7 +43,7 @@ const OverviewTab: React.FC<Props> = ({
       </CardContent>
     </Card>
     <Card>
-      <CardHeader><h3 className="text-lg font-semibold text-gray-900 dark:text-white">Newsletter</h3></CardHeader>
+      <CardHeader><h3 className="text-lg font-semibold text-foreground">Newsletter</h3></CardHeader>
       <CardContent className="space-y-3">
         <Row label="Total posts" value={blogs.length} />
         <Row label="Unique reads" value={totalBlogReads} />
@@ -50,7 +51,7 @@ const OverviewTab: React.FC<Props> = ({
       </CardContent>
     </Card>
     <Card>
-      <CardHeader><h3 className="text-lg font-semibold text-gray-900 dark:text-white">Members</h3></CardHeader>
+      <CardHeader><h3 className="text-lg font-semibold text-foreground">Members</h3></CardHeader>
       <CardContent className="space-y-3">
         <Row label="Total users" value={memberAnalytics?.totalUsers ?? "—"} />
         <Row label="Marketing opt-in" value={memberAnalytics?.marketingOptIn ?? "—"} />
@@ -58,14 +59,14 @@ const OverviewTab: React.FC<Props> = ({
       </CardContent>
     </Card>
     <Card>
-      <CardHeader><h3 className="text-lg font-semibold text-gray-900 dark:text-white">Jobs</h3></CardHeader>
+      <CardHeader><h3 className="text-lg font-semibold text-foreground">Jobs</h3></CardHeader>
       <CardContent className="space-y-3">
         <Row label="Total postings" value={jobs.length} />
         <Row label="Apply clicks" value={totalJobClicks} />
       </CardContent>
     </Card>
     <Card>
-      <CardHeader><h3 className="text-lg font-semibold text-gray-900 dark:text-white">AI Assistant</h3></CardHeader>
+      <CardHeader><h3 className="text-lg font-semibold text-foreground">AI Assistant</h3></CardHeader>
       <CardContent className="space-y-3">
         <Row label="Total chats" value={aiAnalytics?.totalChats ?? "—"} />
         <Row label="Unique users" value={aiAnalytics?.uniqueUsers ?? "—"} />
@@ -73,7 +74,7 @@ const OverviewTab: React.FC<Props> = ({
       </CardContent>
     </Card>
     <Card>
-      <CardHeader><h3 className="text-lg font-semibold text-gray-900 dark:text-white">Team</h3></CardHeader>
+      <CardHeader><h3 className="text-lg font-semibold text-foreground">Team</h3></CardHeader>
       <CardContent className="space-y-3">
         <Row label="Team members" value={teamMembers.length} />
         <Row label="Board positions" value={boardPositions.length} />

--- a/components/pages/admin/tabs/analytics/AnalyticsShared.tsx
+++ b/components/pages/admin/tabs/analytics/AnalyticsShared.tsx
@@ -51,8 +51,8 @@ export const Row: React.FC<{
   value: string | number;
 }> = ({ label, value }) => (
   <div className="flex justify-between text-sm">
-    <span className="text-gray-600 dark:text-gray-400">{label}</span>
-    <span className="font-semibold text-gray-900 dark:text-white">{value}</span>
+    <span className="text-muted-foreground">{label}</span>
+    <span className="font-semibold text-foreground">{value}</span>
   </div>
 );
 
@@ -62,8 +62,8 @@ export const StatCard: React.FC<{ title: string; value: number }> = ({
 }) => (
   <Card>
     <CardContent className="p-4 flex items-center justify-between">
-      <span className="text-sm text-gray-600 dark:text-gray-400">{title}</span>
-      <span className="text-xl font-bold text-gray-900 dark:text-white">
+      <span className="text-sm text-muted-foreground">{title}</span>
+      <span className="text-xl font-bold text-foreground">
         {value}
       </span>
     </CardContent>

--- a/components/pages/admin/tabs/analytics/useAnalyticsData.ts
+++ b/components/pages/admin/tabs/analytics/useAnalyticsData.ts
@@ -4,6 +4,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useApp } from "@/contexts/AppContext";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
+import { subscribeToPositions } from "@/lib/firestore/board-positions";
+import { subscribeToBoardApplications, type BoardApplication } from "@/lib/firestore/boardApplications";
 import { subscribeJobClicks, subscribeEventClicks } from "@/lib/firestore/analytics";
 import { subscribeBlogReads } from "@/lib/firestore/blog";
 import { getMemberAnalytics, type MemberAnalytics } from "@/lib/firestore/member-analytics";
@@ -12,9 +15,19 @@ import { getRegistrationAnalytics, type RegistrationAnalytics } from "@/lib/fire
 import { getAIAnalytics, type AIAnalytics } from "@/lib/firestore/ai-analytics";
 import { fetchFirebaseAnalytics, type FirebaseAnalyticsResponse } from "@/lib/firestore/firebase-analytics";
 import { cumulativeSignups, eventMonthKey } from "./AnalyticsShared";
-import type { Event, BlogPost, Job, TeamMember, BoardPosition, Application } from "@/types";
+import type { Event, BlogPost, Job, TeamMember, BoardPosition } from "@/types";
 
 export type AnalyticsTabKey = "overview" | "events" | "members" | "newsletter" | "jobs" | "ai" | "firebase";
+
+export const ANALYTICS_SUBTABS: { key: AnalyticsTabKey; label: string }[] = [
+  { key: "overview", label: "Summary" },
+  { key: "events", label: "Events" },
+  { key: "members", label: "Members" },
+  { key: "newsletter", label: "Blog" },
+  { key: "jobs", label: "Jobs" },
+  { key: "ai", label: "AI Assistant" },
+  { key: "firebase", label: "Firebase" },
+];
 
 export interface AnalyticsData {
   activeSubtab: AnalyticsTabKey;
@@ -38,13 +51,17 @@ export interface AnalyticsData {
   jobs: Job[];
   teamMembers: TeamMember[];
   boardPositions: BoardPosition[];
-  applicants: Application[];
+  applicants: BoardApplication[];
 }
 
-export function useAnalyticsData(): AnalyticsData {
+export function useAnalyticsData(
+  activeSubtab: AnalyticsTabKey,
+  setActiveSubtab: (key: AnalyticsTabKey) => void
+): AnalyticsData {
   const { state } = useApp();
+  const { data: boardPositions } = useCollectionData<BoardPosition>(subscribeToPositions, []);
+  const { data: applicants } = useCollectionData<BoardApplication>(subscribeToBoardApplications, []);
 
-  const [activeSubtab, setActiveSubtab] = useState<AnalyticsTabKey>("overview");
   const [blogReads, setBlogReads] = useState<Record<string, number>>({});
   const [jobClicks, setJobClicks] = useState<Record<string, number>>({});
   const [eventClicks, setEventClicks] = useState<Record<string, number>>({});
@@ -65,7 +82,13 @@ export function useAnalyticsData(): AnalyticsData {
 
   useEffect(() => {
     if (blogIds.length) {
-      return subscribeBlogReads(blogIds, setBlogReads);
+      try {
+        return subscribeBlogReads(blogIds, setBlogReads);
+      } catch (e) {
+        console.warn("Blog-reads subscription failed:", e);
+        setBlogReads({});
+        return undefined;
+      }
     }
     setBlogReads({});
     return undefined;
@@ -74,7 +97,13 @@ export function useAnalyticsData(): AnalyticsData {
 
   useEffect(() => {
     if (jobIds.length) {
-      return subscribeJobClicks(jobIds, setJobClicks);
+      try {
+        return subscribeJobClicks(jobIds, setJobClicks);
+      } catch (e) {
+        console.warn("Job-clicks subscription failed:", e);
+        setJobClicks({});
+        return undefined;
+      }
     }
     setJobClicks({});
     return undefined;
@@ -83,7 +112,13 @@ export function useAnalyticsData(): AnalyticsData {
 
   useEffect(() => {
     if (eventIds.length) {
-      return subscribeEventClicks(eventIds, setEventClicks);
+      try {
+        return subscribeEventClicks(eventIds, setEventClicks);
+      } catch (e) {
+        console.warn("Event-clicks subscription failed:", e);
+        setEventClicks({});
+        return undefined;
+      }
     }
     setEventClicks({});
     return undefined;
@@ -167,7 +202,7 @@ export function useAnalyticsData(): AnalyticsData {
     blogs: state.blogPosts,
     jobs: state.jobs,
     teamMembers: state.teamMembers,
-    boardPositions: state.boardPositions,
-    applicants: state.applicants,
+    boardPositions,
+    applicants,
   };
 }

--- a/components/pages/admin/tabs/membersTab.tsx
+++ b/components/pages/admin/tabs/membersTab.tsx
@@ -96,13 +96,14 @@ export default function MembersTab() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (opts?: { notify?: boolean }) => {
     setLoading(true);
     try {
       const u = await listUsers();
       u.sort((a, b) => (b.updatedAt || "").localeCompare(a.updatedAt || ""));
       setUsers(u);
-      notify({ type: 'success', message: 'Members refreshed.' });
+      // Notify only on an explicit user-triggered refresh — silent on mount/save/delete.
+      if (opts?.notify) notify({ type: 'success', message: 'Members refreshed.' });
     } finally {
       setLoading(false);
     }
@@ -325,14 +326,10 @@ export default function MembersTab() {
               <Trash2 className="h-4 w-4" aria-hidden /> {deleting ? 'Deleting...' : 'Delete'}
             </Button>
             <div className="flex gap-2">
-              <Button className="px-3 py-2 border border-border rounded-md" onClick={close} disabled={saving || deleting}>
+              <Button variant="secondary" onClick={close} disabled={saving || deleting}>
                 Cancel
               </Button>
-              <Button
-                className="px-3 py-2 bg-primary text-primary-foreground rounded-md"
-                onClick={onSave}
-                disabled={saving || deleting}
-              >
+              <Button variant="outline" onClick={onSave} disabled={saving || deleting}>
                 {saving ? 'Saving...' : 'Save'}
               </Button>
             </div>
@@ -363,7 +360,7 @@ export default function MembersTab() {
             filter={filter}
             setFilter={setFilter}
             loading={loading} 
-            onRefresh={refresh}
+            onRefresh={() => refresh({ notify: true })}
           />
         </div>
       </div>

--- a/components/pages/admin/tabs/membersTab.tsx
+++ b/components/pages/admin/tabs/membersTab.tsx
@@ -10,10 +10,6 @@ import { Download, Trash2} from 'lucide-react';
 
 type EditableUser = UserProfile & Record<string, unknown>;
 
-type MembersTabProps = {
-  onChanged?: () => void;
-};
-
 const fieldOrder: string[] = [
   "displayName",
   "name",
@@ -86,7 +82,7 @@ const SortableTh: React.FC<SortableThProps> = ({ column, sortKey, sortDir, onTog
   </th>
 );
 
-export default function MembersTab({ onChanged }: MembersTabProps) {
+export default function MembersTab() {
   const { notify } = useNotify();
   const [loading, setLoading] = useState(false);
   const [users, setUsers] = useState<EditableUser[]>([]);
@@ -179,7 +175,6 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
       update.updatedAt = new Date().toISOString();
       await updateUserProfile(selected.id, update);
       await refresh();
-      onChanged?.();
       close();
       notify({ type: 'success', title: 'Saved', message: 'Member updated.' });
     } finally {
@@ -193,7 +188,6 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
     try {
       await deleteUser(selected.id);
       await refresh();
-      onChanged?.();
       close();
       notify({ type: 'success', title: 'Deleted', message: 'Member deleted.' });
     } finally {

--- a/components/pages/admin/tabs/membersTab.tsx
+++ b/components/pages/admin/tabs/membersTab.tsx
@@ -78,7 +78,7 @@ const SortableTh: React.FC<SortableThProps> = ({ column, sortKey, sortDir, onTog
     >
       {children}
       {sortKey === column && (
-        <span aria-hidden="true" className="text-xs text-gray-400 dark:text-gray-500">
+        <span aria-hidden="true" className="text-xs text-muted-foreground">
           {sortDir === 'asc' ? '▲' : '▼'}
         </span>
       )}
@@ -246,13 +246,13 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
               if (booleanFields.has(k)) {
                 return (
                   <div key={k} className="flex items-center gap-2">
-                    <label className="inline-flex items-center gap-2 text-gray-800 dark:text-gray-200">
+                    <label className="inline-flex items-center gap-2 text-foreground">
                       <input
                         type="checkbox"
                         checked={Boolean(val)}
                         onChange={(e) => onChangeField(k, e.target.checked)}
                       />
-                      <span className="text-xs text-gray-600 dark:text-gray-400">{k}</span>
+                      <span className="text-xs text-muted-foreground">{k}</span>
                     </label>
                   </div>
                 );
@@ -261,7 +261,7 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
               if (enumOptions[k]) {
                 return (
                   <div key={k} className="flex flex-col gap-1">
-                    <label className="text-xs text-gray-600 dark:text-gray-400">{k}</label>
+                    <label className="text-xs text-muted-foreground">{k}</label>
                     <select
                       className="input"
                       value={val === undefined ? '' : String(val)}
@@ -281,7 +281,7 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
               if (k === 'expectedGraduationYear') {
                 return (
                   <div key={k} className="flex flex-col gap-1">
-                    <label className="text-xs text-gray-600 dark:text-gray-400">{k}</label>
+                    <label className="text-xs text-muted-foreground">{k}</label>
                     <input
                       className="input"
                       type="number"
@@ -298,7 +298,7 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
                 const dateVal = iso ? new Date(iso).toISOString().slice(0, 16) : '';
                 return (
                   <div key={k} className="flex flex-col gap-1">
-                    <label className="text-xs text-gray-600 dark:text-gray-400">{k}</label>
+                    <label className="text-xs text-muted-foreground">{k}</label>
                     <input
                       className="input"
                       type="datetime-local"
@@ -311,7 +311,7 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
 
               return (
                 <div key={k} className="flex flex-col gap-1">
-                  <label className="text-xs text-gray-600 dark:text-gray-400">{k}</label>
+                  <label className="text-xs text-muted-foreground">{k}</label>
                   <input
                     className="input"
                     value={String(val ?? '')}
@@ -331,11 +331,11 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
               <Trash2 className="h-4 w-4" aria-hidden /> {deleting ? 'Deleting...' : 'Delete'}
             </Button>
             <div className="flex gap-2">
-              <Button className="px-3 py-2 border rounded-md" onClick={close} disabled={saving || deleting}>
+              <Button className="px-3 py-2 border border-border rounded-md" onClick={close} disabled={saving || deleting}>
                 Cancel
               </Button>
               <Button
-                className="px-3 py-2 bg-blue-600 text-white rounded-md"
+                className="px-3 py-2 bg-primary text-primary-foreground rounded-md"
                 onClick={onSave}
                 disabled={saving || deleting}
               >
@@ -360,7 +360,7 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between flex-wrap gap-2">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Members</h2>
+        <h2 className="text-xl font-semibold tracking-[-0.028em] text-foreground">Members</h2>
         <div className="flex items-center gap-2">
           <Button variant="outline" icon={Download} onClick={() => downloadCsv(users)}>
             CSV
@@ -376,7 +376,7 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
 
       <div className="overflow-x-auto">
         <table className="min-w-full text-left text-sm">
-          <thead className="text-gray-600 dark:text-gray-300">
+          <thead className="text-muted-foreground">
             <tr>
               <SortableTh column="name" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort}>Name</SortableTh>
               <SortableTh column="email" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort}>Email</SortableTh>
@@ -388,24 +388,24 @@ export default function MembersTab({ onChanged }: MembersTabProps) {
               <th className="py-2 pr-4"></th>
             </tr>
           </thead>
-          <tbody className="text-gray-800 dark:text-gray-200">
+          <tbody className="text-foreground">
             {loading ? (
               <tr>
-                <td className="py-3" colSpan={6}>
+                <td className="py-3 text-center text-muted-foreground" colSpan={8}>
                   Loading...
                 </td>
               </tr>
             ) : filtered.length === 0 ? (
               <tr>
-                <td className="py-3" colSpan={6}>
-                  No users
+                <td className="py-8 text-center text-muted-foreground" colSpan={8}>
+                  No users match your search.
                 </td>
               </tr>
             ) : (
               paginated.map((m) => (
                 <tr
                   key={m.id}
-                  className="border-t border-gray-200 dark:border-gray-700 hover:bg-gray-50/50 dark:hover:bg-gray-800/50"
+                  className="border-t border-border hover:bg-foreground/[0.03]"
                 >
                   <td className="py-2 pr-4">{m.name || m.displayName || "-"}</td>
                   <td className="py-2 pr-4">{m.email || "-"}</td>

--- a/components/pages/admin/useAdminOverview.ts
+++ b/components/pages/admin/useAdminOverview.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useApp } from "@/contexts/AppContext";
 import { useCollectionData } from "@/lib/firestore/useCollectionData";
-import { subscribeAllCampaigns } from "@/lib/firestore/applicationCampaigns";
+import { subscribeOpenCampaigns } from "@/lib/firestore/applicationCampaigns";
 import { subscribeToTeamApplications } from "@/lib/firestore/teamApplications";
 import type { ApplicationCampaign, TeamApplication } from "@/types";
 
@@ -28,7 +28,7 @@ export interface AdminActionItem {
 /** Live "what needs attention" signals for the admin shell; subscribes to the admin-only collections while the dashboard is mounted. */
 export function useAdminOverview(): { items: AdminActionItem[]; loaded: boolean } {
   const { state } = useApp();
-  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeAllCampaigns, []);
+  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeOpenCampaigns, []);
   const { data: teamApplications, loaded: teamApplicationsLoaded } = useCollectionData<TeamApplication>(subscribeToTeamApplications, []);
 
   return useMemo(() => {

--- a/components/pages/admin/useAdminOverview.ts
+++ b/components/pages/admin/useAdminOverview.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import { useApp } from "@/contexts/AppContext";
+import { useCollectionData } from "@/lib/firestore/useCollectionData";
+import { subscribeAllCampaigns } from "@/lib/firestore/applicationCampaigns";
+import { subscribeToTeamApplications } from "@/lib/firestore/teamApplications";
+import type { ApplicationCampaign, TeamApplication } from "@/types";
+
+export type AdminTabKey =
+  | "events"
+  | "team"
+  | "blog"
+  | "faq"
+  | "analytics"
+  | "members"
+  | "jobs"
+  | "ai-settings"
+  | "applications"
+  | "board-applications";
+
+export interface AdminActionItem {
+  tab: AdminTabKey;
+  label: string;
+  count: number;
+}
+
+/** Live "what needs attention" signals for the admin shell; subscribes to the admin-only collections while the dashboard is mounted. */
+export function useAdminOverview(): { items: AdminActionItem[]; loaded: boolean } {
+  const { state } = useApp();
+  const { data: campaigns, loaded: campaignsLoaded } = useCollectionData<ApplicationCampaign>(subscribeAllCampaigns, []);
+  const { data: teamApplications, loaded: teamApplicationsLoaded } = useCollectionData<TeamApplication>(subscribeToTeamApplications, []);
+
+  return useMemo(() => {
+    const items: AdminActionItem[] = [];
+
+    for (const campaign of campaigns) {
+      if (campaign.status !== "open") continue;
+      const subs = teamApplications.filter((s) => s.campaignId === campaign.id).length;
+      if (subs > 0) {
+        items.push({ tab: "applications", label: `New submission${subs !== 1 ? "s" : ""} · ${campaign.title}`, count: subs });
+      }
+    }
+
+    const drafts = state.blogPosts.filter((p) => !p.published).length;
+    if (drafts > 0) {
+      items.push({ tab: "blog", label: `Draft post${drafts !== 1 ? "s" : ""} to review`, count: drafts });
+    }
+
+    const unpublishedEvents = state.events.filter((e) => e.published === false).length;
+    if (unpublishedEvents > 0) {
+      items.push({ tab: "events", label: `Unpublished event${unpublishedEvents !== 1 ? "s" : ""}`, count: unpublishedEvents });
+    }
+
+    // Positive signal: real registrations on the most recent published event.
+    const latest = state.events
+      .filter((e) => e.published && e.eventStartAt && Number.isFinite(Date.parse(e.eventStartAt)))
+      .sort((a, b) => Date.parse(b.eventStartAt) - Date.parse(a.eventStartAt))[0];
+    if (latest && (latest.currentRegistrations ?? 0) > 0) {
+      items.push({ tab: "events", label: `registered for ${latest.title}`, count: latest.currentRegistrations ?? 0 });
+    }
+
+    const loaded = campaignsLoaded && teamApplicationsLoaded && state.blogPostsLoaded && state.eventsLoaded;
+
+    return { items, loaded };
+  }, [campaigns, campaignsLoaded, teamApplications, teamApplicationsLoaded, state.blogPosts, state.blogPostsLoaded, state.events, state.eventsLoaded]);
+}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -51,7 +51,7 @@ export function Modal({
         >
           <div
             className={cn(
-              "bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-h-[90vh] overflow-y-auto shadow-xl",
+              "bg-card rounded-lg p-6 w-full max-h-[90vh] overflow-y-auto shadow-xl",
               sizes[size],
               className,
             )}
@@ -67,10 +67,10 @@ export function Modal({
                 <div className="flex justify-between items-start mb-4 gap-4">
                   <div>
                     <Dialog.Title asChild>
-                      <h2 className="text-xl font-bold text-gray-900 dark:text-white">{title}</h2>
+                      <h2 className="text-xl font-bold text-foreground">{title}</h2>
                     </Dialog.Title>
                     {description && (
-                      <Dialog.Description className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                      <Dialog.Description className="mt-1 text-sm text-muted-foreground">
                         {description}
                       </Dialog.Description>
                     )}
@@ -79,7 +79,7 @@ export function Modal({
                     <button
                       type="button"
                       aria-label="Close dialog"
-                      className="size-9 grid place-items-center rounded-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-700/60 transition-colors cursor-pointer"
+                      className="size-9 grid place-items-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-foreground/[0.05] transition-colors cursor-pointer"
                     >
                       <X className="h-5 w-5" />
                     </button>

--- a/components/ui/TabErrorBoundary.tsx
+++ b/components/ui/TabErrorBoundary.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Card, CardContent } from "./Card";
+import { Button } from "./Button";
 
 interface Props {
   children: React.ReactNode;
@@ -23,13 +24,20 @@ export class TabErrorBoundary extends React.Component<Props, State> {
     return { hasError: true, error };
   }
 
+  private reset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
   render() {
     if (this.state.hasError) {
       return (
         <Card>
           <CardContent className="p-6">
-            <p className="text-red-600 dark:text-red-400 font-medium">Failed to load {this.props.name} tab.</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{this.state.error?.message}</p>
+            <p className="text-primary font-medium">Failed to load {this.props.name} tab.</p>
+            <p className="text-sm text-muted-foreground mt-1">{this.state.error?.message}</p>
+            <Button size="sm" variant="outline" className="mt-4" onClick={this.reset}>
+              Try again
+            </Button>
           </CardContent>
         </Card>
       );

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import React, { createContext, useContext, useReducer, ReactNode, useEffect } from 'react';
-import { Event, TeamMember, BlogPost, FAQ, Job, BoardPosition, Application, ApplicationCampaign, TeamApplication } from '../types';
-import type { CampaignInput } from '@/lib/firestore/applicationCampaigns';
+import { Event, TeamMember, BlogPost, FAQ, Job } from '../types';
 import { scheduleIdle } from '@/lib/idle';
 import { hasCachedIdentity } from '@/lib/identity-cache';
 
@@ -14,11 +13,6 @@ interface AppState {
   blogPostsLoaded: boolean;
   faqs: FAQ[];
   jobs: Job[];
-  boardPositions: BoardPosition[];
-  applicants: Application[];
-  campaigns: ApplicationCampaign[];
-  campaignsLoaded: boolean;
-  teamApplications: TeamApplication[];
   isLoading: boolean;
   error: string | null;
 }
@@ -42,18 +36,10 @@ type AppAction =
   | { type: 'ADD_FAQS'; payload: FAQ }
   | { type: 'UPDATE_FAQS'; payload: FAQ }
   | { type: 'DELETE_FAQS'; payload: string }
-  | { type: 'SET_BOARDPOS'; payload: BoardPosition[] }
-  | { type: 'ADD_BOARDPOS'; payload: BoardPosition }
-  | { type: 'UPDATE_BOARDPOS'; payload: BoardPosition }
-  | { type: 'DELETE_BOARDPOS'; payload: string }
   | { type: 'SET_JOBS'; payload: Job[] }
   | { type: 'ADD_JOB'; payload: Job }
   | { type: 'UPDATE_JOB'; payload: Job }
-  | { type: 'DELETE_JOB'; payload: string }
-  | { type: 'SET_APPLICANTS'; payload: Application[] }
-  | { type: 'SET_CAMPAIGNS'; payload: ApplicationCampaign[] }
-  | { type: 'SET_CAMPAIGNS_LOADED'; payload: boolean }
-  | { type: 'SET_TEAM_APPLICATIONS'; payload: TeamApplication[] };
+  | { type: 'DELETE_JOB'; payload: string };
 
 type FirestoreAction = 
   | { firestoreAction: 'ADD_EVENT'; payload: Omit<Event, 'id'> }
@@ -69,18 +55,9 @@ type FirestoreAction =
   | { firestoreAction: 'ADD_FAQS'; payload: Omit<FAQ, 'id'> }
   | { firestoreAction: 'UPDATE_FAQS'; payload: FAQ }
   | { firestoreAction: 'DELETE_FAQS'; payload: string }
-  | { firestoreAction: 'ADD_BOARDPOS'; payload: Omit<BoardPosition, 'id' | 'order'> }
-  | { firestoreAction: 'UPDATE_BOARDPOS'; payload: BoardPosition }
-  | { firestoreAction: 'DELETE_BOARDPOS'; payload: string }
-  | { firestoreAction: 'MOVE_BOARDPOS'; payload: { positionId: string; direction: 'up' | 'down' } }
   | { firestoreAction: 'ADD_JOB'; payload: Omit<Job, 'id' | 'createdAt'> }
   | { firestoreAction: 'UPDATE_JOB'; payload: Job }
-  | { firestoreAction: 'DELETE_JOB'; payload: string }
-  | { firestoreAction: 'DELETE_BOARD_APPLICATION'; payload: string }
-  | { firestoreAction: 'ADD_CAMPAIGN'; payload: CampaignInput }
-  | { firestoreAction: 'UPDATE_CAMPAIGN'; payload: Partial<ApplicationCampaign> }
-  | { firestoreAction: 'DELETE_CAMPAIGN'; payload: string }
-  | { firestoreAction: 'DELETE_TEAM_APPLICATION'; payload: string };
+  | { firestoreAction: 'DELETE_JOB'; payload: string };
 
 const initialState: AppState = {
   events: [],
@@ -90,11 +67,6 @@ const initialState: AppState = {
   blogPostsLoaded: false,
   faqs: [],
   jobs: [],
-  boardPositions: [],
-  applicants: [],
-  campaigns: [],
-  campaignsLoaded: false,
-  teamApplications: [],
   isLoading: false,
   error: null
 };
@@ -181,28 +153,6 @@ const appReducer = (state: AppState, action: AppAction): AppState => {
         ...state,
         jobs: state.jobs.filter(j => j.id !== action.payload)
       };
-    case 'SET_BOARDPOS':
-      return { ...state, boardPositions: action.payload };
-    case 'ADD_BOARDPOS':
-      return { ...state, boardPositions: [...state.boardPositions, action.payload] };
-    case 'UPDATE_BOARDPOS':
-      return {
-        ...state,
-        boardPositions: state.boardPositions.map(j => j.id === action.payload.id ? action.payload : j)
-      };
-    case 'DELETE_BOARDPOS':
-      return {
-        ...state,
-        boardPositions: state.boardPositions.filter(j => j.id !== action.payload)
-      };
-    case 'SET_APPLICANTS':
-      return { ...state, applicants: action.payload };
-    case 'SET_CAMPAIGNS':
-      return { ...state, campaigns: action.payload };
-    case 'SET_CAMPAIGNS_LOADED':
-      return { ...state, campaignsLoaded: action.payload };
-    case 'SET_TEAM_APPLICATIONS':
-      return { ...state, teamApplications: action.payload };
     default:
       return state;
   }
@@ -218,27 +168,44 @@ const AppContext = createContext<{
 export const AppProvider: React.FC<{
   children: ReactNode;
   seed?: Partial<
-    Pick<AppState, 'events' | 'jobs' | 'faqs' | 'teamMembers' | 'boardPositions' | 'campaigns' | 'blogPosts'>
+    Pick<AppState, 'events' | 'jobs' | 'faqs' | 'teamMembers' | 'blogPosts'>
   >;
 }> = ({ children, seed }) => {
   const initState: AppState = {
     ...initialState,
     ...(seed || {}),
     eventsLoaded: !!seed?.events,
-    campaignsLoaded: !!seed?.campaigns,
     blogPostsLoaded: seed ? seed.blogPosts !== undefined : false,
   };
   const [state, dispatch] = useReducer(appReducer, initState);
+
+  // Swallow only the Firestore SDK's unhandled internal assertions (thrown when a denied watch stream is torn down) so they can't brick a screen via an error boundary.
+  useEffect(() => {
+    const isFirestoreInternal = (msg: string) =>
+      msg.includes("INTERNAL ASSERTION FAILED") || msg.includes("INTERNAL UNHANDLED ERROR");
+    const onError = (event: ErrorEvent) => {
+      if (isFirestoreInternal(event.message || "")) {
+        event.preventDefault();
+      }
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      if (isFirestoreInternal(String((event.reason as { message?: string })?.message || ""))) {
+        event.preventDefault();
+      }
+    };
+    window.addEventListener("error", onError, true);
+    window.addEventListener("unhandledrejection", onRejection, true);
+    return () => {
+      window.removeEventListener("error", onError, true);
+      window.removeEventListener("unhandledrejection", onRejection, true);
+    };
+  }, []);
 
   // Realtime Firestore listeners start after the main thread goes idle so they stay out of the critical network chain (LCP); SSR-seeded data already paints the content.
   useEffect(() => {
     // Listener refs are mutated async (dynamic import) so a late chunk from a superseded subscribe() can't clobber the active one.
     const unsubscribeEvents: { current: (() => void) | null } = { current: null };
     const unsubscribeJobs: { current: (() => void) | null } = { current: null };
-    const unsubscribeBoardPositions: { current: (() => void) | null } = { current: null };
-    const unsubscribeBoardApplications: { current: (() => void) | null } = { current: null };
-    const unsubscribeCampaigns: { current: (() => void) | null } = { current: null };
-    const unsubscribeTeamApplications: { current: (() => void) | null } = { current: null };
     const unsubscribeBlogPosts: { current: (() => void) | null } = { current: null };
     const unsubscribeTeamMembers: { current: (() => void) | null } = { current: null };
     const unsubscribeFaqs: { current: (() => void) | null } = { current: null };
@@ -287,57 +254,6 @@ export const AppProvider: React.FC<{
         subscribeToJobs((jobs) => {
           dispatch({ type: 'SET_JOBS', payload: jobs });
         }, { includeUnpublished }),
-      );
-
-      if (unsubscribeBoardPositions.current) {
-        try { unsubscribeBoardPositions.current(); } catch { /* ignore */ }
-        unsubscribeBoardPositions.current = null;
-      }
-      attach(import('@/lib/firestore/board-positions'), unsubscribeBoardPositions, ({ subscribeToPositions }) =>
-        subscribeToPositions((positions) => {
-          dispatch({ type: 'SET_BOARDPOS', payload: positions });
-        }),
-      );
-
-      if (unsubscribeBoardApplications.current) {
-        try { unsubscribeBoardApplications.current(); } catch { /* ignore */ }
-        unsubscribeBoardApplications.current = null;
-      }
-      if (includeUnpublished) {
-        attach(import('@/lib/firestore/boardApplications'), unsubscribeBoardApplications, ({ subscribeToBoardApplications }) =>
-          subscribeToBoardApplications((applications) => {
-            dispatch({ type: 'SET_APPLICANTS', payload: applications as Application[] });
-          }),
-        );
-      } else {
-        dispatch({ type: 'SET_APPLICANTS', payload: [] });
-      }
-
-      // Team applications: admin-only subscription
-      if (unsubscribeTeamApplications.current) {
-        try { unsubscribeTeamApplications.current(); } catch { /* ignore */ }
-        unsubscribeTeamApplications.current = null;
-      }
-      if (includeUnpublished) {
-        attach(import('@/lib/firestore/teamApplications'), unsubscribeTeamApplications, ({ subscribeToTeamApplications }) =>
-          subscribeToTeamApplications((applications) => {
-            dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: applications as TeamApplication[] });
-          }),
-        );
-      } else {
-        dispatch({ type: 'SET_TEAM_APPLICATIONS', payload: [] });
-      }
-
-      // Campaigns: public visitors only see open campaigns; admins see all (incl. drafts)
-      if (unsubscribeCampaigns.current) {
-        try { unsubscribeCampaigns.current(); } catch { /* ignore */ }
-        unsubscribeCampaigns.current = null;
-      }
-      attach(import('@/lib/firestore/applicationCampaigns'), unsubscribeCampaigns, ({ subscribeToCampaigns }) =>
-        subscribeToCampaigns((campaigns) => {
-          dispatch({ type: 'SET_CAMPAIGNS', payload: campaigns });
-          dispatch({ type: 'SET_CAMPAIGNS_LOADED', payload: true });
-        }, { includeAll: includeUnpublished }),
       );
 
       // Blog posts: public visitors see published posts; admins see all (incl. drafts)
@@ -413,18 +329,6 @@ export const AppProvider: React.FC<{
       if (unsubscribeJobs.current) {
         try { unsubscribeJobs.current(); } catch { /* ignore */ }
       }
-      if (unsubscribeBoardPositions.current) {
-        try { unsubscribeBoardPositions.current(); } catch { /* ignore */ }
-      }
-      if (unsubscribeBoardApplications.current) {
-        try { unsubscribeBoardApplications.current(); } catch { /* ignore */ }
-      }
-      if (unsubscribeCampaigns.current) {
-        try { unsubscribeCampaigns.current(); } catch { /* ignore */ }
-      }
-      if (unsubscribeTeamApplications.current) {
-        try { unsubscribeTeamApplications.current(); } catch { /* ignore */ }
-      }
       if (unsubscribeBlogPosts.current) {
         try { unsubscribeBlogPosts.current(); } catch { /* ignore */ }
       }
@@ -489,18 +393,6 @@ export const AppProvider: React.FC<{
           case 'DELETE_FAQS':
             await (await import('@/lib/firestore/faqs')).deleteFaq(action.payload);
             break;
-          case 'ADD_BOARDPOS':
-            await (await import('@/lib/firestore/board-positions')).addPosition(action.payload);
-            break;
-          case 'UPDATE_BOARDPOS':
-            await (await import('@/lib/firestore/board-positions')).updatePosition(action.payload.id, action.payload);
-            break;
-          case 'DELETE_BOARDPOS':
-            await (await import('@/lib/firestore/board-positions')).deletePosition(action.payload);
-            break;
-          case 'MOVE_BOARDPOS':
-            await (await import('@/lib/firestore/board-positions')).movePosition(state.boardPositions, action.payload.positionId, action.payload.direction);
-            break;
           case 'ADD_JOB':
             return await (await import('@/lib/firestore/jobs')).addJob(action.payload);
           case 'UPDATE_JOB':
@@ -508,24 +400,6 @@ export const AppProvider: React.FC<{
             break;
           case 'DELETE_JOB':
             await (await import('@/lib/firestore/jobs')).deleteJob(action.payload);
-            break;
-          case 'DELETE_BOARD_APPLICATION':
-            await (await import('@/lib/firestore/boardApplications')).deleteBoardApplication(action.payload);
-            break;
-          case 'ADD_CAMPAIGN':
-            return await (await import('@/lib/firestore/applicationCampaigns')).addCampaign(action.payload);
-          case 'UPDATE_CAMPAIGN':
-            if (action.payload.id) {
-              await (await import('@/lib/firestore/applicationCampaigns')).updateCampaign(action.payload.id, action.payload);
-            }
-            break;
-          case 'DELETE_CAMPAIGN':
-            await (await import('@/lib/firestore/applicationCampaigns')).deleteCampaign(action.payload);
-            // Also clean up campaign questions
-            try { await (await import('@/lib/firestore/campaignQuestions')).deleteCampaignQuestionsByCampaign(action.payload); } catch { /* ignore */ }
-            break;
-          case 'DELETE_TEAM_APPLICATION':
-            await (await import('@/lib/firestore/teamApplications')).deleteTeamApplication(action.payload);
             break;
         }
       } else {

--- a/docs/data-fetching-and-state.md
+++ b/docs/data-fetching-and-state.md
@@ -1,30 +1,63 @@
 # Data fetching and state in this project
 
-This project uses Next.js + TypeScript + Tailwind CSS with Firebase (Firestore + Auth). All app-wide data is loaded and kept up-to-date in real time through a single React context: `contexts/AppContext.tsx`. Components read that state via `useApp()` instead of fetching directly.
+This project uses Next.js + TypeScript + Tailwind CSS with Firebase (Firestore + Auth). App-wide *public* data is loaded and kept up-to-date in real time through a single React context: `contexts/AppContext.tsx`. Components read that state via `useApp()` instead of fetching directly. Admin-only data is *not* global: the admin dashboard's tabs fetch their own collections with `useCollectionData`.
 
 This guide explains:
 - How `AppContext` works
 - What the actions and `dispatch` do
 - What "subscribe"/"unsubscribe" mean
-- What `lib/firestore.ts` exports and how to use it
-- Why `state.events` could be empty and what we changed
+- Why admin collections are tab-scoped (`useCollectionData`)
+- How to use state in components
 
 
 ## AppContext (contexts/AppContext.tsx)
 
-- **Purpose**: Provide a single source of truth for app data like events, blog posts, team members, FAQs, and registration questions.
+- **Purpose**: Provide a single source of truth for app data like events, blog posts, team members, FAQs, and jobs.
+- **What it subscribes to**: the public streams — `subscribeToEvents`, `subscribeToJobs`, `subscribeToBlogPosts`, `subscribeToTeamMembers`, `subscribeToFaqs`. Admin-only collections (board positions, board applications, campaigns, team applications) are **not** subscribed here; the admin dashboard fetches them per tab.
 - **How it works**:
-  1. `AppProvider` sets up real-time Firestore subscriptions using helpers from `lib/firestore.ts`:
+  1. `AppProvider` sets up real-time Firestore subscriptions using helpers from `lib/firestore/`:
      - `subscribeToEvents`
      - `subscribeToTeamMembers`
      - `subscribeToBlogPosts`
      - `subscribeToFaqs`
-     - `subscribeToRegistrationQuestions`
+     - `subscribeToJobs`
   2. Each subscription calls `dispatch({ type: 'SET_...', payload })` whenever the underlying collection changes in Firestore.
   3. The reducer updates the in-memory state (`state.events`, `state.blogPosts`, etc.).
   4. Components read this state by calling `const { state } = useApp()` and using `state.events`, `state.blogPosts`, etc.
 
+- **Admin visibility**: when the signed-in user holds the `admin` claim, the events/jobs/blog subscriptions re-run with `includeUnpublished: true` so admins see drafts too.
+
 - **Why this pattern**: Centralizing all reads keeps data consistent across pages and components, avoids duplicate network calls, and ensures changes appear everywhere in real time.
+
+
+## Admin-only data is tab-scoped (`useCollectionData`)
+
+The admin dashboard no longer loads all collections up-front. Collections that only admins need — board positions, board applications, application campaigns, team applications — are subscribed by the tabs that use them, and torn down when the tab unmounts.
+
+`lib/firestore/useCollectionData.ts` provides a small hook:
+
+```tsx
+import { useCollectionData } from '@/lib/firestore/useCollectionData';
+import { subscribeToPositions } from '@/lib/firestore/board-positions';
+
+const { data: positions, loaded } = useCollectionData<BoardPosition>(subscribeToPositions, []);
+```
+
+- Pass a stable subscribe function (e.g. `subscribeToPositions`) or a named helper such as `subscribeOpenCampaigns` / `subscribeAllCampaigns` (in `lib/firestore/applicationCampaigns.ts`).
+- The `deps` array mirrors `useEffect` deps — with an inline closure, pass `[]` so the listener is created once.
+- The listener is set up on mount and torn down on unmount, so switching tabs only pays for the collections that are actually open.
+
+Where each admin collection is subscribed:
+
+| Collection | Subscribed by |
+| --- | --- |
+| board positions | `BoardTab`, `BoardApplicationPage` (public), analytics |
+| board applications | `BoardTab`, `useAdminOverview` (status strip), analytics |
+| application campaigns (all) | `ApplicationsTab`, `useAdminOverview` |
+| application campaigns (open only) | `Header`, `TeamApplicationPage` |
+| team applications | `ApplicationsTab`, `useAdminOverview` |
+
+Public pages that need a slice of this data (the header's Apply link, the apply forms) subscribe locally with the public view (`subscribeOpenCampaigns`, `subscribeToPositions`) instead of reading it from `AppContext`.
 
 
 ## Actions and dispatch
@@ -43,38 +76,21 @@ This guide explains:
 
 The provider wraps the reducer with an "enhanced" dispatcher that:
 - Sets loading and clears errors
-- Performs the Firestore operation by calling helpers in `lib/firestore.ts`
+- Performs the Firestore operation by calling helpers in `lib/firestore/`
 - Relies on the real-time subscription to update the state after the write completes
 - Unsets loading
 
 This means you don't manually set new arrays after writes; the subscriptions do it for you.
 
+Firestore actions cover the public collections (events, blog, team, FAQs, jobs). Admin-only collections are written by calling their `lib/firestore/*` helpers directly from the owning tab — for example `addPosition`/`updatePosition` in `BoardTab`, `addCampaign`/`updateCampaign` in `ApplicationsTab` — and their realtime subscriptions refresh the UI.
+
 
 ## Subscribe and unsubscribe
 
-- **Subscribe**: Establishes a live connection to Firestore for a given query. In our project, functions like `subscribeToEvents` call Firestore's `onSnapshot(...)` with a query (e.g., `events` ordered by `date`). Firestore sends an initial snapshot and pushes updates whenever data changes.
+- **Subscribe**: Establishes a live connection to Firestore for a given query. Functions like `subscribeToEvents` call Firestore's `onSnapshot(...)` with a query (e.g., `events` ordered by `date`). Firestore sends an initial snapshot and pushes updates whenever data changes.
 
-- **Unsubscribe**: The `onSnapshot(...)` call returns a function. Calling it closes the listener and frees resources. In `AppProvider`, we save that function in a variable like `unsubscribeEvents` and call it in a `useEffect` cleanup so listeners are removed when the provider unmounts.
+- **Unsubscribe**: The `onSnapshot(...)` call returns a function. Calling it closes the listener and frees resources. In `AppProvider`, we save that function and call it in a `useEffect` cleanup so listeners are removed when the provider unmounts. `useCollectionData` does the same for tab-scoped listeners.
 
-This is important for performance, correctness, and avoiding memory leaks.
-
-
-## lib/firestore.ts (data helpers)
-
-This file contains all typed helpers for reading/writing Firestore data and setting up subscriptions.
-
-- **Reads (one-off)**:
-  - `getEvents()`, `getBlogPosts()`, etc. Useful for server-side rendering or specific pages.
-
-- **Writes**:
-  - `addEvent`, `updateEvent`, `deleteEvent`, `addBlogPost`, etc.
-  - `registerForEvent(eventId, payload)` creates a document in the `registrations` collection and increments `currentRegistrations` on the event when appropriate.
-
-- **Real-time subscriptions**:
-  - `subscribeToEvents(cb)`, `subscribeToBlogPosts(cb)`, etc. These call `onSnapshot(query, ...)` under the hood and invoke your callback with an up-to-date array whenever data changes.
-
-- **Client-side analytics helpers**:
-  - `incrementEventUniqueClick(eventId)` and `incrementBlogRead(blogId)` use `localStorage` to ensure one increment per browser per day, and then write an atomic increment to Firestore.
 
 ## How to use state in components
 
@@ -119,4 +135,5 @@ Note: You do not set `state.events` directly after the write. The real-time subs
 ## Security, performance, and UX notes
 
 - **Performance**: Subscribing once in the provider prevents duplicate listeners. Unsubscribe on unmount to avoid leaks.
-- **UX**: Use `state.isLoading` and `state.error` to show spinners and messages as needed. Keep lists sorted by using `orderBy(...)` in subscription queries as done in `lib/firestore.ts`.
+- **Performance**: Admin-only collections are fetched per tab so switching tabs only pays for the collections that are actually open — no all-collections-up-front subscription for admins.
+- **UX**: Use `state.isLoading` and `state.error` to show spinners and messages as needed. Keep lists sorted by using `orderBy(...)` in subscription queries as done in `lib/firestore/`.

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -46,10 +46,12 @@ declare global {
   var __setMockParams: ((params: Record<string, string>) => void) | undefined;
   var __setAppState: ((state: Record<string, unknown> | null) => void) | undefined;
   var __setAdminState: ((state: Record<string, unknown> | null) => void) | undefined;
+  var __setCollectionData: ((entries: Record<string, unknown> | null) => void) | undefined;
 }
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
+  global.__setCollectionData?.(null);
 });
 
 if (typeof window !== 'undefined') {
@@ -177,6 +179,20 @@ global.__setAppState = (state: Record<string, unknown> | null) => {
 jest.mock('@/contexts/AppContext', () => ({
   useApp: () => ({ state: __mockAppState || __defaultAppState, dispatch: jest.fn() }),
   AppProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+let __mockCollectionData: Record<string, unknown> = {};
+const __defaultCollectionData = { data: [], loaded: false };
+// Keyed by the subscribe function's name so re-renders (filters, expands) get the same data; 'default' covers anonymous/inline subscribe functions.
+global.__setCollectionData = (entries: Record<string, unknown> | null) => {
+  __mockCollectionData = entries || {};
+};
+jest.mock('@/lib/firestore/useCollectionData', () => ({
+  useCollectionData: (subscribe: unknown) => {
+    const name = typeof subscribe === 'function' && subscribe.name ? subscribe.name : 'default';
+    const entry = __mockCollectionData[name];
+    return entry !== undefined ? entry : __defaultCollectionData;
+  },
 }));
 
 jest.mock("@/utils/seo", () => ({

--- a/lib/firestore/applicationCampaigns.ts
+++ b/lib/firestore/applicationCampaigns.ts
@@ -127,3 +127,11 @@ export function subscribeToCampaigns(callback: (campaigns: ApplicationCampaign[]
     }
   );
 }
+
+/** Public view — open campaigns only (used by the header and apply flows). */
+export const subscribeOpenCampaigns = (callback: (campaigns: ApplicationCampaign[]) => void) =>
+  subscribeToCampaigns(callback, { includeAll: false });
+
+/** Admin view — all campaigns including drafts. */
+export const subscribeAllCampaigns = (callback: (campaigns: ApplicationCampaign[]) => void) =>
+  subscribeToCampaigns(callback, { includeAll: true });

--- a/lib/firestore/useCollectionData.ts
+++ b/lib/firestore/useCollectionData.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Subscribe to a Firestore collection for as long as the component is mounted; pass a stable subscribe function (or an inline one with matching deps). */
+export function useCollectionData<T>(
+  subscribe: (callback: (items: T[]) => void) => () => void,
+  deps: unknown[] = []
+): { data: T[]; loaded: boolean } {
+  const [data, setData] = useState<T[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribe: (() => void) | null = null;
+    try {
+      unsubscribe = subscribe((items) => {
+        if (!active) return;
+        setData(items);
+        setLoaded(true);
+      });
+    } catch (e) {
+      // A denied watch stream can leave the SDK broken so new onSnapshot() calls throw; treat as empty-but-loaded instead of crashing the tab.
+      console.warn("Firestore subscription error:", e);
+      queueMicrotask(() => {
+        if (active) setLoaded(true);
+      });
+    }
+    return () => {
+      active = false;
+      // unsubscribe() can also throw synchronously after a rejected watch stream; swallow so a tab switch can't bubble an SDK assertion into the error boundary.
+      try {
+        unsubscribe?.();
+      } catch (e) {
+        console.warn("Firestore listener teardown error:", e);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { data, loaded };
+}

--- a/lib/firestore/useOpenCampaigns.ts
+++ b/lib/firestore/useOpenCampaigns.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ApplicationCampaign } from "@/types";
+
+/**
+ * Public open-campaigns subscription, loaded via dynamic import so the global
+ * header never eagerly pulls the Firestore client into the critical path.
+ */
+export function useOpenCampaigns(): { campaigns: ApplicationCampaign[]; loaded: boolean } {
+  const [campaigns, setCampaigns] = useState<ApplicationCampaign[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribe: (() => void) | null = null;
+    void import("@/lib/firestore/applicationCampaigns")
+      .then(({ subscribeOpenCampaigns }) => {
+        if (!active) return;
+        try {
+          unsubscribe = subscribeOpenCampaigns((list) => {
+            if (!active) return;
+            setCampaigns(list);
+            setLoaded(true);
+          });
+        } catch (e) {
+          console.warn("Open-campaigns subscription error:", e);
+          if (active) setLoaded(true);
+        }
+      })
+      .catch((e) => {
+        console.warn("Failed to load campaigns module:", e);
+        if (active) setLoaded(true);
+      });
+    return () => {
+      active = false;
+      try {
+        unsubscribe?.();
+      } catch (e) {
+        console.warn("Open-campaigns teardown error:", e);
+      }
+    };
+  }, []);
+
+  return { campaigns, loaded };
+}

--- a/lib/mcp/uuais-admin.ts
+++ b/lib/mcp/uuais-admin.ts
@@ -45,6 +45,19 @@ async function withSeed<T>(build: (seed: PublicSeed) => T) {
   }
 }
 
+/** Board positions + open campaigns are admin-facing data, fetched directly (not via the public SSR seed). */
+async function getPositionsAndCampaigns() {
+  const { adminDb } = await import('@/lib/firebase-admin');
+  const [positionsSnap, campaignsSnap] = await Promise.all([
+    adminDb.collection('board-positions').orderBy('order', 'asc').get(),
+    adminDb.collection('applicationCampaigns').where('status', '==', 'open').get(),
+  ]);
+  return {
+    positions: positionsSnap.docs.map((d) => ({ id: d.id, ...d.data() })),
+    campaigns: campaignsSnap.docs.map((d) => ({ id: d.id, ...d.data() })),
+  };
+}
+
 export function createUuaisMcpServer(): McpServer {
   const server = new McpServer(
     { name: 'uuais-admin', version: '0.1.0' },
@@ -148,8 +161,15 @@ export function createUuaisMcpServer(): McpServer {
       inputSchema: z.object({}),
       annotations: READ_ONLY_ANNOTATIONS,
     },
-    async () =>
-      withSeed((seed) => ({ positions: seed.boardPositions, campaigns: seed.campaigns })),
+    async () => {
+      try {
+        const { positions, campaigns } = await getPositionsAndCampaigns();
+        return jsonText({ positions, campaigns });
+      } catch (error) {
+        console.error('[mcp] getPositionsAndCampaigns failed:', error);
+        return jsonText({ available: false });
+      }
+    },
   );
 
   server.registerTool(
@@ -164,21 +184,26 @@ export function createUuaisMcpServer(): McpServer {
       }),
       annotations: READ_ONLY_ANNOTATIONS,
     },
-    async ({ eventLimit }) =>
-      withSeed((seed) => {
+    async ({ eventLimit }) => {
+      try {
+        const [seed, { positions, campaigns }] = await Promise.all([getPublicSeedForMcp(), getPositionsAndCampaigns()]);
         const now = new Date().toISOString();
-        return {
+        return jsonText({
           overview: {
             available: true,
             upcomingEvents: seed.events.filter((e) => e.eventStartAt >= now).slice(0, eventLimit),
-            boardPositions: seed.boardPositions,
-            openCampaigns: seed.campaigns,
+            boardPositions: positions,
+            openCampaigns: campaigns,
             openJobs: seed.jobs.length,
             faqCount: seed.faqs.length,
             teamCount: seed.teamMembers.length,
           },
-        };
-      }),
+        });
+      } catch (error) {
+        console.error('[mcp] getUuaisOverview failed:', error);
+        return jsonText({ available: false });
+      }
+    },
   );
 
   server.registerTool(

--- a/lib/mcp/uuais-data.ts
+++ b/lib/mcp/uuais-data.ts
@@ -273,8 +273,6 @@ export async function getSiteStats(): Promise<SiteStats> {
         jobs: seed.jobs.length,
         faqs: seed.faqs.length,
         teamMembers: seed.teamMembers.length,
-        boardPositions: seed.boardPositions.length,
-        openCampaigns: seed.campaigns.length,
         blogPosts: blog?.length ?? null,
         courses: courses?.length ?? null,
       },

--- a/lib/server-data.ts
+++ b/lib/server-data.ts
@@ -1,12 +1,10 @@
-import type { ApplicationCampaign, BoardPosition, Event, FAQ, Job, TeamMember } from '@/types';
+import type { Event, FAQ, Job, TeamMember } from '@/types';
 
 export interface PublicSeed {
   events: Event[];
   jobs: Job[];
   faqs: FAQ[];
   teamMembers: TeamMember[];
-  boardPositions: BoardPosition[];
-  campaigns: ApplicationCampaign[];
 }
 
 const EMPTY_SEED: PublicSeed = {
@@ -14,8 +12,6 @@ const EMPTY_SEED: PublicSeed = {
   jobs: [],
   faqs: [],
   teamMembers: [],
-  boardPositions: [],
-  campaigns: [],
 };
 
 function isTimestampLike(value: unknown): value is { toDate: () => Date } {
@@ -66,13 +62,11 @@ export async function getPublicSeed(options?: { throwOnError?: boolean }): Promi
     // throwing during module evaluation.
     const { adminDb } = await import('@/lib/firebase-admin');
 
-    const [eventsSnap, jobsSnap, faqsSnap, teamSnap, positionsSnap, campaignsSnap] = await Promise.all([
+    const [eventsSnap, jobsSnap, faqsSnap, teamSnap] = await Promise.all([
       adminDb.collection('events').where('published', '==', true).orderBy('eventStartAt', 'desc').get(),
       adminDb.collection('jobs').where('published', '==', true).orderBy('createdAt', 'desc').get(),
       adminDb.collection('faqs').orderBy('order', 'asc').get(),
       adminDb.collection('teamMembers').orderBy('order', 'asc').get(),
-      adminDb.collection('board-positions').orderBy('order', 'asc').get(),
-      adminDb.collection('applicationCampaigns').where('status', '==', 'open').get(),
     ]);
 
     return {
@@ -80,8 +74,6 @@ export async function getPublicSeed(options?: { throwOnError?: boolean }): Promi
       jobs: jobsSnap.docs.map((d) => normalizeDoc<Job>(d)),
       faqs: faqsSnap.docs.map((d) => normalizeDoc<FAQ>(d)),
       teamMembers: teamSnap.docs.map((d) => normalizeDoc<TeamMember>(d)),
-      boardPositions: positionsSnap.docs.map((d) => normalizeDoc<BoardPosition>(d)),
-      campaigns: campaignsSnap.docs.map((d) => normalizeDoc<ApplicationCampaign>(d)),
     };
   } catch (error) {
     if (options?.throwOnError) throw error;


### PR DESCRIPTION
## Description

Redesigns the admin dashboard from a monolithic, legacy-styled page into a clean, tokenized operational surface that matches the site's "Frosted Society Notebook" design system (issue #72). The shell is a sticky left sidebar with expandable sub-tab groups, a harmonized header, and an actionable "what needs attention" status strip. Architecture is refactored so admin-only data no longer flows through the public app context and each tab owns its own data + state.

## Related issue

Closes #72

## Changes

- **New shell**: sticky left sidebar (vertical on desktop, horizontal scroll + fade on mobile) with expandable groups for Blog (Posts / AI News Desk) and Analytics (7 sections); `?tab=<name>&sub=<sub>` deep links and tab/sub persistence
- **Status strip**: live actionable signals in mono counts (drafts, unpublished events, new submissions, engagement) instead of vanity stat cards; navigates to the relevant tab
- **Per-tab data fetching**: new `useCollectionData` hook; board positions, board applications, campaigns, and team applications removed from `AppContext` and subscribed per-tab; public pages (Header, apply flows) subscribe their own public views
- **Co-located state**: blog/FAQ/board/campaign modals + CRUD moved into their tabs; `AdminDashboard` is no longer a ~600-line monolith
- **Design-system harmonization**: entire admin surface (shell, all tab bodies, analytics suite, modals) tokenized; consistent icon scale; tab headings match sidebar labels
- **Hardening**: guarded Firestore subscription teardown and analytics listeners against SDK internal assertion crashes; resettable tab error boundary; AI-settings load timeout; empty/loading states on every tab; error toasts on failed writes
- **Docs**: `docs/data-fetching-and-state.md` updated to reflect the new per-tab architecture

## Testing

Verified locally (`npm run dev`) and via three independent browser E2E rounds (including a 40/40 rapid tab-switch hammer under denied subscriptions). Tests updated for the new headings/data flow.

- [x] Tested locally (`npm run dev`)
- [x] Existing tests still pass
- [x] Added/updated tests for new or changed functionality

## Checklist before review

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` is clean
- [x] `npm test` passes (unit) — 1004 passed
- [x] `npm run test:integration` passes (API routes) — 162 passed
- [x] `npm run test:e2e` passes (Playwright smoke tests), if UI changed — 8 passed
- [x] Branch named per conventions (`feature/*`, `fix/*`, `docs/*`, `refactor/*`)
- [x] No secrets or `.env` values committed
